### PR TITLE
Abillity to retrieve comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ pip-delete-this-directory.txt
 
 # pyenv
 .python-version 
+.aider*

--- a/README.md
+++ b/README.md
@@ -232,23 +232,23 @@ checkin_to_show(
 
 ### Comment Tools
 ```python
-# Get comments for a movie
+# Get comments for a movie (sorted by newest by default)
 fetch_movie_comments(movie_id="123", limit=10, show_spoilers=False)
 
-# Get comments for a show
-fetch_show_comments(show_id="456", limit=10, show_spoilers=False)
+# Get comments for a show sorted by most likes
+fetch_show_comments(show_id="456", limit=10, show_spoilers=False, sort="likes")
 
-# Get comments for a specific season
-fetch_season_comments(show_id="456", season=1, limit=10, show_spoilers=False)
+# Get comments for a specific season sorted by highest rating
+fetch_season_comments(show_id="456", season=1, limit=10, show_spoilers=False, sort="highest")
 
-# Get comments for a specific episode
-fetch_episode_comments(show_id="456", season=1, episode=3, limit=10, show_spoilers=False)
+# Get comments for a specific episode sorted by most replies
+fetch_episode_comments(show_id="456", season=1, episode=3, limit=10, show_spoilers=False, sort="replies")
 
 # Get a specific comment
 fetch_comment(comment_id="789", show_spoilers=False)
 
-# Get a comment with its replies
-fetch_comment_replies(comment_id="789", limit=10, show_spoilers=False)
+# Get a comment with its replies sorted by oldest first
+fetch_comment_replies(comment_id="789", limit=10, show_spoilers=False, sort="oldest")
 ```
 
 ## 🔐 Authentication
@@ -324,6 +324,9 @@ Once installed, you can ask Claude questions like:
 - "Show me comment #12345 with its replies"
 - "Show me comments for Breaking Bad but include spoilers"
 - "Search for movies like 'The Godfather'"
+- "Show me the most liked comments for Breaking Bad" (uses sort="likes")
+- "Get the highest rated comments for The Godfather movie" (uses sort="highest")
+- "Show me the comments with most replies for Season 1 of Stranger Things" (uses sort="replies")
 
 Claude will use this MCP server to provide you with real-time data from Trakt.
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ This entire project was developed using [Cursor](https://cursor.sh/), a code edi
 - Secure authentication with Trakt through device code flow
 - Personal data is fetched directly from your Trakt account
 
+### 💬 Comments & Reviews
+- **View comments for shows and movies**: Read what others are saying about your favorite content
+- **See comments for specific seasons and episodes**: Get insights about particular parts of a show
+- **View individual comments and their replies**: Engage with the community's discussions
+- **Spoiler protection**: Comments with spoilers are hidden by default
+- **Toggle spoiler visibility**: Choose whether to show or hide spoilers
+- **View reviews**: Longer, more detailed comments are marked as reviews
+
 ### 🔄 General Features
 - Exposes Trakt API data through MCP resources
 - Provides tools for fetching real-time entertainment information
@@ -124,6 +132,16 @@ The hottest movies right now:
 | `trakt://user/watched/shows` | Shows watched by the authenticated user | Show title, year, last watched date, play count |
 | `trakt://user/watched/movies` | Movies watched by the authenticated user | Movie title, year, last watched date, play count |
 
+### Comment Resources
+| Resource | Description | Example Data |
+|----------|-------------|--------------|
+| `trakt://comments/movie/:id` | Comments for a specific movie | Comment text, author, date, likes |
+| `trakt://comments/show/:id` | Comments for a specific show | Comment text, author, date, likes |
+| `trakt://comments/show/:id/season/:season` | Comments for a specific season | Comment text, author, date, likes |
+| `trakt://comments/show/:id/season/:season/episode/:episode` | Comments for a specific episode | Comment text, author, date, likes |
+| `trakt://comments/:id` | A specific comment | Comment text, author, date, likes |
+| `trakt://comments/:id/replies` | Replies to a specific comment | Reply text, author, date |
+
 ## 🛠️ Available Tools
 
 ### Show Tools
@@ -145,6 +163,9 @@ fetch_watched_shows(limit=10, period="weekly")
 
 # Search for shows by title to get show IDs and details
 search_shows(query="Breaking Bad", limit=5)
+
+# Search for movies by title to get movie IDs and details
+search_movies(query="The Godfather", limit=5)
 ```
 
 ### Movie Tools
@@ -207,6 +228,27 @@ checkin_to_show(
     share_mastodon=False,
     share_tumblr=False
 )
+```
+
+### Comment Tools
+```python
+# Get comments for a movie
+fetch_movie_comments(movie_id="123", limit=10, show_spoilers=False)
+
+# Get comments for a show
+fetch_show_comments(show_id="456", limit=10, show_spoilers=False)
+
+# Get comments for a specific season
+fetch_season_comments(show_id="456", season=1, limit=10, show_spoilers=False)
+
+# Get comments for a specific episode
+fetch_episode_comments(show_id="456", season=1, episode=3, limit=10, show_spoilers=False)
+
+# Get a specific comment
+fetch_comment(comment_id="789", show_spoilers=False)
+
+# Get a comment with its replies
+fetch_comment_replies(comment_id="789", limit=10, show_spoilers=False)
 ```
 
 ## 🔐 Authentication
@@ -275,6 +317,13 @@ Once installed, you can ask Claude questions like:
 - "Search for shows like 'Breaking Bad'"
 - "Check me in to Season 2 Episode 5 of Breaking Bad" (uses title)
 - "Check me in to Season 1 Episode 3 of show ID 1388 and share it on Twitter" (uses ID)
+- "Show me comments for Breaking Bad"
+- "What are people saying about The Godfather movie?"
+- "Show me comments for Season 1 of Stranger Things"
+- "Get comments for Season 2 Episode 5 of Game of Thrones"
+- "Show me comment #12345 with its replies"
+- "Show me comments for Breaking Bad but include spoilers"
+- "Search for movies like 'The Godfather'"
 
 Claude will use this MCP server to provide you with real-time data from Trakt.
 

--- a/config.py
+++ b/config.py
@@ -97,7 +97,6 @@ TOOL_NAMES = {
     "fetch_user_watched_shows": "fetch_user_watched_shows",
     "fetch_user_watched_movies": "fetch_user_watched_movies",
     "checkin_to_show": "checkin_to_show",
-    "search_shows": "search_shows",
 
     # Comment tools
     "fetch_movie_comments": "fetch_movie_comments",
@@ -106,5 +105,8 @@ TOOL_NAMES = {
     "fetch_episode_comments": "fetch_episode_comments",
     "fetch_comment": "fetch_comment",
     "fetch_comment_replies": "fetch_comment_replies",
+
+    # Search tools
+    "search_shows": "search_shows",
     "search_movies": "search_movies",
 }

--- a/config.py
+++ b/config.py
@@ -7,25 +7,33 @@ TRAKT_ENDPOINTS = {
     "shows_favorited": "/shows/favorited",
     "shows_played": "/shows/played",
     "shows_watched": "/shows/watched",
-    
+
     # Movie endpoints
     "movies_trending": "/movies/trending",
     "movies_popular": "/movies/popular",
     "movies_favorited": "/movies/favorited",
     "movies_played": "/movies/played",
     "movies_watched": "/movies/watched",
-    
+
     # User authentication endpoints
     "device_code": "/oauth/device/code",
     "device_token": "/oauth/device/token",
-    
+
     # User-specific endpoints
     "user_watched_shows": "/sync/watched/shows",
     "user_watched_movies": "/sync/watched/movies",
     "checkin": "/checkin",
-    
+
     # Search endpoints
     "search": "/search",
+
+    # Comments endpoints
+    "comments_movie": "/movies/:id/comments",
+    "comments_show": "/shows/:id/comments",
+    "comments_season": "/shows/:id/seasons/:season/comments",
+    "comments_episode": "/shows/:id/seasons/:season/episodes/:episode/comments",
+    "comment": "/comments/:id",
+    "comment_replies": "/comments/:id/replies",
 }
 
 # MCP resource URIs
@@ -35,18 +43,26 @@ MCP_RESOURCES = {
     "shows_favorited": "trakt://shows/favorited",
     "shows_played": "trakt://shows/played",
     "shows_watched": "trakt://shows/watched",
-    
+
     # Movie resources
     "movies_trending": "trakt://movies/trending",
     "movies_popular": "trakt://movies/popular",
     "movies_favorited": "trakt://movies/favorited",
     "movies_played": "trakt://movies/played",
     "movies_watched": "trakt://movies/watched",
-    
+
     # User resources
     "user_auth_status": "trakt://user/auth/status",
     "user_watched_shows": "trakt://user/watched/shows",
     "user_watched_movies": "trakt://user/watched/movies",
+
+    # Comment resources
+    "comments_movie": "trakt://comments/movie/:id",
+    "comments_show": "trakt://comments/show/:id",
+    "comments_season": "trakt://comments/show/:id/season/:season",
+    "comments_episode": "trakt://comments/show/:id/season/:season/episode/:episode",
+    "comment": "trakt://comments/:id",
+    "comment_replies": "trakt://comments/:id/replies",
 }
 
 # Default limits for API requests
@@ -64,22 +80,31 @@ TOOL_NAMES = {
     "fetch_favorited_shows": "fetch_favorited_shows",
     "fetch_played_shows": "fetch_played_shows",
     "fetch_watched_shows": "fetch_watched_shows",
-    
+
     # Movie tools
     "fetch_trending_movies": "fetch_trending_movies",
     "fetch_popular_movies": "fetch_popular_movies",
     "fetch_favorited_movies": "fetch_favorited_movies",
     "fetch_played_movies": "fetch_played_movies",
     "fetch_watched_movies": "fetch_watched_movies",
-    
+
     # User authentication tools
     "start_device_auth": "start_device_auth",
     "check_auth_status": "check_auth_status",
     "clear_auth": "clear_auth",
-    
+
     # User-specific tools
     "fetch_user_watched_shows": "fetch_user_watched_shows",
     "fetch_user_watched_movies": "fetch_user_watched_movies",
     "checkin_to_show": "checkin_to_show",
     "search_shows": "search_shows",
-} 
+
+    # Comment tools
+    "fetch_movie_comments": "fetch_movie_comments",
+    "fetch_show_comments": "fetch_show_comments",
+    "fetch_season_comments": "fetch_season_comments",
+    "fetch_episode_comments": "fetch_episode_comments",
+    "fetch_comment": "fetch_comment",
+    "fetch_comment_replies": "fetch_comment_replies",
+    "search_movies": "search_movies",
+}

--- a/config.py
+++ b/config.py
@@ -28,12 +28,12 @@ TRAKT_ENDPOINTS = {
     "search": "/search",
 
     # Comments endpoints
-    "comments_movie": "/movies/:id/comments",
-    "comments_show": "/shows/:id/comments",
-    "comments_season": "/shows/:id/seasons/:season/comments",
-    "comments_episode": "/shows/:id/seasons/:season/episodes/:episode/comments",
+    "comments_movie": "/movies/:id/comments/:sort",
+    "comments_show": "/shows/:id/comments/:sort",
+    "comments_season": "/shows/:id/seasons/:season/comments/:sort",
+    "comments_episode": "/shows/:id/seasons/:season/episodes/:episode/comments/:sort",
     "comment": "/comments/:id",
-    "comment_replies": "/comments/:id/replies",
+    "comment_replies": "/comments/:id/replies/:sort",
 }
 
 # MCP resource URIs

--- a/models.py
+++ b/models.py
@@ -484,4 +484,169 @@ This code will expire in {minutes} minutes. I'll wait for your confirmation that
         # Add a tip for using the search results
         message += "\nTo check in to a show, use the `checkin_to_show` tool with the show ID, season number, and episode number."
         
-        return message 
+        return message
+        
+    @staticmethod
+    def format_movie_search_results(results: List[Dict]) -> str:
+        """Format movie search results from Trakt API."""
+        if not results:
+            return "# Movie Search Results\n\nNo movies found matching your query."
+        
+        message = "# Movie Search Results\n\n"
+        message += "Here are the movies matching your search query:\n\n"
+        
+        for index, item in enumerate(results, 1):
+            movie = item.get("movie", {})
+            
+            title = movie.get("title", "Unknown movie")
+            year = movie.get("year", "")
+            year_str = f" ({year})" if year else ""
+            
+            ids = movie.get("ids", {})
+            trakt_id = ids.get("trakt", "unknown")
+            
+            message += f"**{index}. {title}{year_str}** (ID: {trakt_id})\n"
+            
+            if overview := movie.get("overview"):
+                if len(overview) > 200:
+                    overview = overview[:197] + "..."
+                message += f"  {overview}\n"
+            
+            message += f"  *Use this ID for comments: `{trakt_id}`*\n\n"
+        
+        message += "\nTo view comments for a movie, use the `fetch_movie_comments` tool with the movie ID."
+        
+        return message
+        
+    @staticmethod
+    def format_comments(comments: List[Dict], title: str, show_spoilers: bool = False) -> str:
+        """Format comments for MCP resource."""
+        result = f"# Comments for {title}\n\n"
+        
+        if show_spoilers:
+            result += "**Note: Showing all spoilers**\n\n"
+        else:
+            result += "**Note: Spoilers are hidden. Use `show_spoilers=True` to view them.**\n\n"
+        
+        if not comments:
+            return result + "No comments found."
+        
+        for comment in comments:
+            username = comment.get("user", {}).get("username", "Anonymous")
+            created_at = comment.get("created_at", "Unknown date")
+            comment_text = comment.get("comment", "")
+            spoiler = comment.get("spoiler", False)
+            review = comment.get("review", False)
+            replies = comment.get("replies", 0)
+            likes = comment.get("likes", 0)
+            comment_id = comment.get("id", "")
+            
+            try:
+                created_time = created_at.replace('Z', '').split('.')[0].replace('T', ' ')
+            except:
+                created_time = created_at
+            
+            comment_type = ""
+            if review:
+                comment_type = " [REVIEW]"
+            if spoiler:
+                comment_type += " [SPOILER]"
+            
+            result += f"### {username}{comment_type} - {created_time}\n"
+            
+            if (spoiler or "[spoiler]" in comment_text) and not show_spoilers:
+                result += f"**⚠️ SPOILER WARNING ⚠️**\n\n"
+                result += f"*This comment contains spoilers. Use `show_spoilers=True` to view it.*\n\n"
+            else:
+                if show_spoilers:
+                    comment_text = comment_text.replace("[spoiler]", "")
+                    comment_text = comment_text.replace("[/spoiler]", "")
+                    
+                result += f"{comment_text}\n\n"
+            
+            result += f"*Likes: {likes} | Replies: {replies} | ID: {comment_id}*\n\n"
+            result += "---\n\n"
+        
+        return result
+
+    @staticmethod
+    def format_comment(comment: Dict, with_replies: bool = False, replies: List[Dict] = None, show_spoilers: bool = False) -> str:
+        """Format a single comment with optional replies."""
+        username = comment.get("user", {}).get("username", "Anonymous")
+        created_at = comment.get("created_at", "Unknown date")
+        comment_text = comment.get("comment", "")
+        spoiler = comment.get("spoiler", False)
+        review = comment.get("review", False)
+        replies_count = comment.get("replies", 0)
+        likes = comment.get("likes", 0)
+        comment_id = comment.get("id", "")
+        
+        try:
+            created_time = created_at.replace('Z', '').split('.')[0].replace('T', ' ')
+        except:
+            created_time = created_at
+        
+        comment_type = ""
+        if review:
+            comment_type = " [REVIEW]"
+        if spoiler:
+            comment_type += " [SPOILER]"
+        
+        result = f"# Comment by {username}{comment_type}\n\n"
+        
+        if show_spoilers:
+            result += "**Note: Showing all spoilers**\n\n"
+        else:
+            result += "**Note: Spoilers are hidden. Use `show_spoilers=True` to view them.**\n\n"
+            
+        result += f"**Posted:** {created_time}\n\n"
+        
+        if (spoiler or "[spoiler]" in comment_text) and not show_spoilers:
+            result += f"**⚠️ SPOILER WARNING ⚠️**\n\n"
+            result += f"*This comment contains spoilers. Use `show_spoilers=True` to view it.*\n\n"
+        else:
+            if show_spoilers:
+                comment_text = comment_text.replace("[spoiler]", "")
+                comment_text = comment_text.replace("[/spoiler]", "")
+                
+            result += f"{comment_text}\n\n"
+        
+        result += f"*Likes: {likes} | Replies: {replies_count} | ID: {comment_id}*\n\n"
+        
+        if with_replies and replies:
+            result += "## Replies\n\n"
+            
+            for reply in replies:
+                reply_username = reply.get("user", {}).get("username", "Anonymous")
+                reply_created_at = reply.get("created_at", "Unknown date")
+                reply_text = reply.get("comment", "")
+                reply_spoiler = reply.get("spoiler", False)
+                reply_id = reply.get("id", "")
+                
+                try:
+                    reply_time = reply_created_at.replace('Z', '').split('.')[0].replace('T', ' ')
+                except:
+                    reply_time = reply_created_at
+                
+                reply_type = ""
+                if reply.get("review", False):
+                    reply_type = " [REVIEW]"
+                if reply_spoiler:
+                    reply_type += " [SPOILER]"
+                    
+                result += f"### {reply_username}{reply_type} - {reply_time}\n"
+                
+                if (reply_spoiler or "[spoiler]" in reply_text) and not show_spoilers:
+                    result += f"**⚠️ SPOILER WARNING ⚠️**\n\n"
+                    result += f"*This reply contains spoilers. Use `show_spoilers=True` to view it.*\n\n"
+                else:
+                    if show_spoilers:
+                        reply_text = reply_text.replace("[spoiler]", "")
+                        reply_text = reply_text.replace("[/spoiler]", "")
+                        
+                    result += f"{reply_text}\n\n"
+                
+                result += f"*ID: {reply_id}*\n\n"
+                result += "---\n\n"
+        
+        return result

--- a/server.py
+++ b/server.py
@@ -24,7 +24,7 @@ active_auth_flow = {}
 @mcp.resource(MCP_RESOURCES["user_auth_status"])
 async def get_auth_status() -> str:
     """Returns the current authentication status with Trakt.
-    
+
     Returns:
         Formatted markdown text with authentication status
     """
@@ -39,15 +39,15 @@ async def get_auth_status() -> str:
 async def get_user_watched_shows() -> str:
     """Returns shows that the authenticated user has watched.
     Requires authentication with Trakt.
-    
+
     Returns:
         Formatted markdown text with user's watched shows
     """
     client = TraktClient()
-    
+
     if not client.is_authenticated():
         return "# Authentication Required\n\nYou need to authenticate with Trakt to view your watched shows.\nUse the `start_device_auth` tool to begin authentication."
-    
+
     shows = await client.get_user_watched_shows()
     return FormatHelper.format_user_watched_shows(shows)
 
@@ -56,15 +56,15 @@ async def get_user_watched_shows() -> str:
 async def get_user_watched_movies() -> str:
     """Returns movies that the authenticated user has watched.
     Requires authentication with Trakt.
-    
+
     Returns:
         Formatted markdown text with user's watched movies
     """
     client = TraktClient()
-    
+
     if not client.is_authenticated():
         return "# Authentication Required\n\nYou need to authenticate with Trakt to view your watched movies.\nUse the `start_device_auth` tool to begin authentication."
-    
+
     movies = await client.get_user_watched_movies()
     return FormatHelper.format_user_watched_movies(movies)
 
@@ -73,19 +73,19 @@ async def get_user_watched_movies() -> str:
 @mcp.tool(name=TOOL_NAMES["start_device_auth"])
 async def start_device_auth() -> str:
     """Start the device authentication flow with Trakt.
-    
+
     Returns:
         Authentication instructions for the user
     """
     client = TraktClient()
-    
+
     # Check if already authenticated
     if client.is_authenticated():
         return "You are already authenticated with Trakt."
-    
+
     # Get device code
     device_code_response = await client.get_device_code()
-    
+
     # Store active auth flow
     global active_auth_flow
     active_auth_flow = {
@@ -94,16 +94,16 @@ async def start_device_auth() -> str:
         "interval": device_code_response.interval,
         "last_poll": 0
     }
-    
+
     logger.info(f"Started device auth flow: {active_auth_flow}")
-    
+
     # Return instructions for the user
     instructions = FormatHelper.format_device_auth_instructions(
         device_code_response.user_code,
         AUTH_VERIFICATION_URL,
         device_code_response.expires_in
     )
-    
+
     return f"""{instructions}
 
 I won't automatically check your authentication status until you tell me you've completed the authorization. Once you've finished the authorization process on the Trakt website, simply tell me "I've completed the authorization" and I'll verify it for you."""
@@ -112,12 +112,12 @@ I won't automatically check your authentication status until you tell me you've 
 @mcp.tool(name=TOOL_NAMES["check_auth_status"])
 async def check_auth_status() -> str:
     """Check the status of an ongoing device authentication flow.
-    
+
     Returns:
         Status of the authentication process
     """
     client = TraktClient()
-    
+
     # Check if already authenticated
     if client.is_authenticated():
         return """# Authentication Successful!
@@ -125,26 +125,26 @@ async def check_auth_status() -> str:
 You are now authenticated with Trakt. You can access your personal data using tools like `fetch_user_watched_shows` and `fetch_user_watched_movies`.
 
 If you want to log out at any point, you can use the `clear_auth` tool."""
-    
+
     # Check if there's an active flow
     global active_auth_flow
     if not active_auth_flow or "device_code" not in active_auth_flow:
         return "No active authentication flow. Use the `start_device_auth` tool to begin authentication."
-    
+
     # Check if flow is expired
     current_time = int(time.time())
     if current_time > active_auth_flow["expires_at"]:
         active_auth_flow = {}
         return "Authentication flow expired. Please start a new one with the `start_device_auth` tool."
-    
+
     # Check if it's too early to poll again
     if current_time - active_auth_flow["last_poll"] < active_auth_flow["interval"]:
         seconds_to_wait = active_auth_flow["interval"] - (current_time - active_auth_flow["last_poll"])
         return f"Please wait {seconds_to_wait} seconds before checking again."
-    
+
     # Update last poll time
     active_auth_flow["last_poll"] = current_time
-    
+
     # Try to get token
     token = await client.get_device_token(active_auth_flow["device_code"])
     if token:
@@ -171,16 +171,16 @@ If you've already done this and are still seeing this message, please wait a few
 @mcp.tool(name=TOOL_NAMES["clear_auth"])
 async def clear_auth() -> str:
     """Clear the authentication token, effectively logging the user out of Trakt.
-    
+
     Returns:
         Status message about the logout
     """
     client = TraktClient()
-    
+
     # Clear any active authentication flow
     global active_auth_flow
     active_auth_flow = {}
-    
+
     # Try to clear the token
     if client.clear_auth_token():
         return "You have been successfully logged out of Trakt. Your authentication token has been cleared."
@@ -191,15 +191,15 @@ async def clear_auth() -> str:
 @mcp.tool(name=TOOL_NAMES["fetch_user_watched_shows"])
 async def fetch_user_watched_shows(limit: int = 0) -> str:
     """Fetch shows watched by the authenticated user from Trakt.
-    
+
     Args:
         limit: Maximum number of shows to return (0 for all)
-        
+
     Returns:
         Information about user's watched shows
     """
     client = TraktClient()
-    
+
     if not client.is_authenticated():
         # Start the auth flow automatically
         auth_instructions = await start_device_auth()
@@ -208,28 +208,28 @@ async def fetch_user_watched_shows(limit: int = 0) -> str:
 {auth_instructions}
 
 After you've completed the authorization process on the Trakt website, please tell me "I've completed the authorization" so I can check if it was successful and retrieve your watched shows."""
-    
+
     shows = await client.get_user_watched_shows()
-    
+
     # Apply limit if requested
     if limit > 0 and len(shows) > limit:
         shows = shows[:limit]
-    
+
     return FormatHelper.format_user_watched_shows(shows)
 
 
 @mcp.tool(name=TOOL_NAMES["fetch_user_watched_movies"])
 async def fetch_user_watched_movies(limit: int = 0) -> str:
     """Fetch movies watched by the authenticated user from Trakt.
-    
+
     Args:
         limit: Maximum number of movies to return (0 for all)
-        
+
     Returns:
         Information about user's watched movies
     """
     client = TraktClient()
-    
+
     if not client.is_authenticated():
         # Start the auth flow automatically
         auth_instructions = await start_device_auth()
@@ -238,45 +238,45 @@ async def fetch_user_watched_movies(limit: int = 0) -> str:
 {auth_instructions}
 
 After you've completed the authorization process on the Trakt website, please tell me "I've completed the authorization" so I can check if it was successful and retrieve your watched movies."""
-    
+
     movies = await client.get_user_watched_movies()
-    
+
     # Apply limit if requested
     if limit > 0 and len(movies) > limit:
         movies = movies[:limit]
-    
+
     return FormatHelper.format_user_watched_movies(movies)
 
 
 @mcp.tool(name=TOOL_NAMES["search_shows"])
 async def search_shows(query: str, limit: int = DEFAULT_LIMIT) -> str:
     """Search for shows on Trakt by title.
-    
+
     Args:
         query: Search query string
         limit: Maximum number of results to return
-        
+
     Returns:
         Formatted search results
     """
     client = TraktClient()
-    
+
     # Perform the search
     results = await client.search_shows(query, limit)
-    
+
     # Format and return the results
     return FormatHelper.format_show_search_results(results)
 
 
 @mcp.tool(name=TOOL_NAMES["checkin_to_show"])
-async def checkin_to_show(season: int, episode: int, show_id: str = None, show_title: str = None, 
-                         show_year: int = None, message: str = "", share_twitter: bool = False, 
+async def checkin_to_show(season: int, episode: int, show_id: str = None, show_title: str = None,
+                         show_year: int = None, message: str = "", share_twitter: bool = False,
                          share_mastodon: bool = False, share_tumblr: bool = False) -> str:
     """Check in to a show episode that the user is currently watching.
-    
+
     This will mark the episode as watched on Trakt and can optionally share to connected social media.
     First use the search_shows tool to find the correct show_id before checking in, or provide the show title.
-    
+
     Args:
         season: Season number
         episode: Episode number
@@ -287,12 +287,12 @@ async def checkin_to_show(season: int, episode: int, show_id: str = None, show_t
         share_twitter: Whether to share this checkin on Twitter
         share_mastodon: Whether to share this checkin on Mastodon
         share_tumblr: Whether to share this checkin on Tumblr
-        
+
     Returns:
         Confirmation of the checkin
     """
     client = TraktClient()
-    
+
     if not client.is_authenticated():
         # Start the auth flow automatically
         auth_instructions = await start_device_auth()
@@ -301,17 +301,17 @@ async def checkin_to_show(season: int, episode: int, show_id: str = None, show_t
 {auth_instructions}
 
 After you've completed the authorization process on the Trakt website, please tell me "I've completed the authorization" so I can check if it was successful and check you in to the show."""
-    
+
     # Validate that either show_id or show_title is provided
     if not show_id and not show_title:
         return "Error: You must provide either a show_id or a show_title. Use the search_shows tool to find the correct show ID."
-    
+
     try:
         # Attempt to check in to the show
         response = await client.checkin_to_show(
-            episode_season=season, 
-            episode_number=episode, 
-            show_id=show_id, 
+            episode_season=season,
+            episode_number=episode,
+            show_id=show_id,
             show_title=show_title,
             show_year=show_year,
             message=message,
@@ -319,7 +319,7 @@ After you've completed the authorization process on the Trakt website, please te
             share_mastodon=share_mastodon,
             share_tumblr=share_tumblr
         )
-        
+
         # Format the response
         return FormatHelper.format_checkin_response(response)
     except ValueError as e:
@@ -333,7 +333,7 @@ After you've completed the authorization process on the Trakt website, please te
 Make sure you provided either:
 1. A valid show ID (use search_shows to find it)
    Example: `search_shows(query="Breaking Bad")`
-   
+
 OR
 
 2. A show title (and optionally the year)
@@ -344,7 +344,7 @@ OR
 @mcp.resource(MCP_RESOURCES["shows_trending"])
 async def get_trending_shows() -> str:
     """Returns the most watched shows over the last 24 hours from Trakt. Shows with the most watchers are returned first.
-    
+
     Returns:
         Formatted markdown text with trending shows
     """
@@ -356,7 +356,7 @@ async def get_trending_shows() -> str:
 @mcp.resource(MCP_RESOURCES["shows_popular"])
 async def get_popular_shows() -> str:
     """Returns the most popular shows from Trakt. Popularity is calculated using the rating percentage and the number of ratings.
-    
+
     Returns:
         Formatted markdown text with popular shows
     """
@@ -368,24 +368,24 @@ async def get_popular_shows() -> str:
 @mcp.resource(MCP_RESOURCES["shows_favorited"])
 async def get_favorited_shows() -> str:
     """Returns the most favorited shows from Trakt in the specified time period, defaulting to weekly. All stats are relative to the specific time period.
-    
+
     Returns:
         Formatted markdown text with most favorited shows
     """
     client = TraktClient()
     shows = await client.get_favorited_shows(limit=DEFAULT_LIMIT)
-    
+
     # Log the first show to see the structure
     if shows and len(shows) > 0:
         logger.info(f"Favorited shows API response structure: {json.dumps(shows[0], indent=2)}")
-    
+
     return FormatHelper.format_favorited_shows(shows)
 
 
 @mcp.resource(MCP_RESOURCES["shows_played"])
 async def get_played_shows() -> str:
     """Returns the most played (a single user can watch multiple episodes multiple times) shows from Traktin the specified time period, defaulting to weekly. All stats are relative to the specific time period.
-    
+
     Returns:
         Formatted markdown text with most played shows
     """
@@ -397,7 +397,7 @@ async def get_played_shows() -> str:
 @mcp.resource(MCP_RESOURCES["shows_watched"])
 async def get_watched_shows() -> str:
     """Returns the most watched (unique users) shows from Traktin the specified time period, defaulting to weekly. All stats are relative to the specific time period.
-    
+
     Returns:
         Formatted markdown text with most watched shows
     """
@@ -409,7 +409,7 @@ async def get_watched_shows() -> str:
 @mcp.resource(MCP_RESOURCES["movies_trending"])
 async def get_trending_movies() -> str:
     """Returns the most watched movies over the last 24 hours from Trakt. Movies with the most watchers are returned first.
-    
+
     Returns:
         Formatted markdown text with trending movies
     """
@@ -421,7 +421,7 @@ async def get_trending_movies() -> str:
 @mcp.resource(MCP_RESOURCES["movies_popular"])
 async def get_popular_movies() -> str:
     """Returns the most popular movies from Trakt. Popularity is calculated using the rating percentage and the number of ratings.
-    
+
     Returns:
         Formatted markdown text with popular movies
     """
@@ -433,24 +433,24 @@ async def get_popular_movies() -> str:
 @mcp.resource(MCP_RESOURCES["movies_favorited"])
 async def get_favorited_movies() -> str:
     """Returns the most favorited movies from Trakt in the specified time period, defaulting to weekly. All stats are relative to the specific time period.
-    
+
     Returns:
         Formatted markdown text with most favorited movies
     """
     client = TraktClient()
     movies = await client.get_favorited_movies(limit=DEFAULT_LIMIT)
-    
+
     # Log the first movie to see the structure
     if movies and len(movies) > 0:
         logger.info(f"Favorited movies API response structure: {json.dumps(movies[0], indent=2)}")
-    
+
     return FormatHelper.format_favorited_movies(movies)
 
 
 @mcp.resource(MCP_RESOURCES["movies_played"])
 async def get_played_movies() -> str:
     """Returns the most played (a single user can watch a single movie multiple times) movies from Trakt in the specified time period, defaulting to weekly. All stats are relative to the specific time period.
-    
+
     Returns:
         Formatted markdown text with most played movies
     """
@@ -462,7 +462,7 @@ async def get_played_movies() -> str:
 @mcp.resource(MCP_RESOURCES["movies_watched"])
 async def get_watched_movies() -> str:
     """Returns the most watched (unique users) movies from Trakt in the specified time period, defaulting to weekly. All stats are relative to the specific time period.
-    
+
     Returns:
         Formatted markdown text with most watched movies
     """
@@ -474,10 +474,10 @@ async def get_watched_movies() -> str:
 @mcp.tool(name=TOOL_NAMES["fetch_trending_shows"])
 async def fetch_trending_shows(limit: int = DEFAULT_LIMIT) -> str:
     """Fetch trending shows from Trakt.
-    
+
     Args:
         limit: Maximum number of shows to return
-        
+
     Returns:
         Information about trending shows
     """
@@ -489,10 +489,10 @@ async def fetch_trending_shows(limit: int = DEFAULT_LIMIT) -> str:
 @mcp.tool(name=TOOL_NAMES["fetch_popular_shows"])
 async def fetch_popular_shows(limit: int = DEFAULT_LIMIT) -> str:
     """Fetch popular shows from Trakt.
-    
+
     Args:
         limit: Maximum number of shows to return
-        
+
     Returns:
         Information about popular shows
     """
@@ -504,32 +504,32 @@ async def fetch_popular_shows(limit: int = DEFAULT_LIMIT) -> str:
 @mcp.tool(name=TOOL_NAMES["fetch_favorited_shows"])
 async def fetch_favorited_shows(limit: int = DEFAULT_LIMIT, period: str = "weekly") -> str:
     """Fetch most favorited shows from Trakt.
-    
+
     Args:
         limit: Maximum number of shows to return
         period: Time period for favorite calculation (daily, weekly, monthly, yearly, all)
-        
+
     Returns:
         Information about most favorited shows
     """
     client = TraktClient()
     shows = await client.get_favorited_shows(limit=limit, period=period)
-    
+
     # Log the first show to see the structure
     if shows and len(shows) > 0:
         logger.info(f"Favorited shows API response structure: {json.dumps(shows[0], indent=2)}")
-    
+
     return FormatHelper.format_favorited_shows(shows)
 
 
 @mcp.tool(name=TOOL_NAMES["fetch_played_shows"])
 async def fetch_played_shows(limit: int = DEFAULT_LIMIT, period: str = "weekly") -> str:
     """Fetch most played shows from Trakt.
-    
+
     Args:
         limit: Maximum number of shows to return
         period: Time period for most played (daily, weekly, monthly, yearly, all)
-        
+
     Returns:
         Information about most played shows
     """
@@ -541,11 +541,11 @@ async def fetch_played_shows(limit: int = DEFAULT_LIMIT, period: str = "weekly")
 @mcp.tool(name=TOOL_NAMES["fetch_watched_shows"])
 async def fetch_watched_shows(limit: int = DEFAULT_LIMIT, period: str = "weekly") -> str:
     """Fetch most watched shows from Trakt.
-    
+
     Args:
         limit: Maximum number of shows to return
         period: Time period for most watched (daily, weekly, monthly, yearly, all)
-        
+
     Returns:
         Information about most watched shows
     """
@@ -557,10 +557,10 @@ async def fetch_watched_shows(limit: int = DEFAULT_LIMIT, period: str = "weekly"
 @mcp.tool(name=TOOL_NAMES["fetch_trending_movies"])
 async def fetch_trending_movies(limit: int = DEFAULT_LIMIT) -> str:
     """Fetch trending movies from Trakt.
-    
+
     Args:
         limit: Maximum number of movies to return
-        
+
     Returns:
         Information about trending movies
     """
@@ -572,10 +572,10 @@ async def fetch_trending_movies(limit: int = DEFAULT_LIMIT) -> str:
 @mcp.tool(name=TOOL_NAMES["fetch_popular_movies"])
 async def fetch_popular_movies(limit: int = DEFAULT_LIMIT) -> str:
     """Fetch popular movies from Trakt.
-    
+
     Args:
         limit: Maximum number of movies to return
-        
+
     Returns:
         Information about popular movies
     """
@@ -587,32 +587,32 @@ async def fetch_popular_movies(limit: int = DEFAULT_LIMIT) -> str:
 @mcp.tool(name=TOOL_NAMES["fetch_favorited_movies"])
 async def fetch_favorited_movies(limit: int = DEFAULT_LIMIT, period: str = "weekly") -> str:
     """Fetch most favorited movies from Trakt.
-    
+
     Args:
         limit: Maximum number of movies to return
         period: Time period for favorite calculation (daily, weekly, monthly, yearly, all)
-        
+
     Returns:
         Information about most favorited movies
     """
     client = TraktClient()
     movies = await client.get_favorited_movies(limit=limit, period=period)
-    
+
     # Log the first movie to see the structure
     if movies and len(movies) > 0:
         logger.info(f"Favorited movies API response structure: {json.dumps(movies[0], indent=2)}")
-    
+
     return FormatHelper.format_favorited_movies(movies)
 
 
 @mcp.tool(name=TOOL_NAMES["fetch_played_movies"])
 async def fetch_played_movies(limit: int = DEFAULT_LIMIT, period: str = "weekly") -> str:
     """Fetch most played movies from Trakt.
-    
+
     Args:
         limit: Maximum number of movies to return
         period: Time period for most played (daily, weekly, monthly, yearly, all)
-        
+
     Returns:
         Information about most played movies
     """
@@ -624,11 +624,11 @@ async def fetch_played_movies(limit: int = DEFAULT_LIMIT, period: str = "weekly"
 @mcp.tool(name=TOOL_NAMES["fetch_watched_movies"])
 async def fetch_watched_movies(limit: int = DEFAULT_LIMIT, period: str = "weekly") -> str:
     """Fetch most watched movies from Trakt.
-    
+
     Args:
         limit: Maximum number of movies to return
         period: Time period for most watched (daily, weekly, monthly, yearly, all)
-        
+
     Returns:
         Information about most watched movies
     """
@@ -637,8 +637,152 @@ async def fetch_watched_movies(limit: int = DEFAULT_LIMIT, period: str = "weekly
     return FormatHelper.format_watched_movies(movies)
 
 
+@mcp.tool(name=TOOL_NAMES["fetch_movie_comments"])
+async def fetch_movie_comments(movie_id: str, limit: int = DEFAULT_LIMIT, show_spoilers: bool = False) -> str:
+    """Fetch comments for a movie from Trakt.
+
+    Args:
+        movie_id: Trakt ID of the movie
+        limit: Maximum number of comments to return
+        show_spoilers: Whether to show spoilers by default
+
+    Returns:
+        Information about movie comments
+    """
+    client = TraktClient()
+
+    try:
+        movie = await client.get_movie(movie_id)
+        title = f"Movie: {movie.get('title', 'Unknown')}"
+    except:
+        title = f"Movie ID: {movie_id}"
+
+    comments = await client.get_movie_comments(movie_id, limit=limit)
+    return FormatHelper.format_comments(comments, title, show_spoilers=show_spoilers)
+
+@mcp.tool(name=TOOL_NAMES["fetch_show_comments"])
+async def fetch_show_comments(show_id: str, limit: int = DEFAULT_LIMIT, show_spoilers: bool = False) -> str:
+    """Fetch comments for a show from Trakt.
+
+    Args:
+        show_id: Trakt ID of the show
+        limit: Maximum number of comments to return
+        show_spoilers: Whether to show spoilers by default
+
+    Returns:
+        Information about show comments
+    """
+    client = TraktClient()
+
+    try:
+        show = await client.get_show(show_id)
+        title = f"Show: {show.get('title', 'Unknown')}"
+    except:
+        title = f"Show ID: {show_id}"
+
+    comments = await client.get_show_comments(show_id, limit=limit)
+    return FormatHelper.format_comments(comments, title, show_spoilers=show_spoilers)
+
+@mcp.tool(name=TOOL_NAMES["fetch_season_comments"])
+async def fetch_season_comments(show_id: str, season: int, limit: int = DEFAULT_LIMIT, show_spoilers: bool = False) -> str:
+    """Fetch comments for a season from Trakt.
+
+    Args:
+        show_id: Trakt ID of the show
+        season: Season number
+        limit: Maximum number of comments to return
+        show_spoilers: Whether to show spoilers by default
+
+    Returns:
+        Information about season comments
+    """
+    client = TraktClient()
+
+    try:
+        show = await client.get_show(show_id)
+        title = f"Show: {show.get('title', 'Unknown')} - Season {season}"
+    except:
+        title = f"Show ID: {show_id} - Season {season}"
+
+    comments = await client.get_season_comments(show_id, season, limit=limit)
+    return FormatHelper.format_comments(comments, title, show_spoilers=show_spoilers)
+
+@mcp.tool(name=TOOL_NAMES["fetch_episode_comments"])
+async def fetch_episode_comments(show_id: str, season: int, episode: int, limit: int = DEFAULT_LIMIT, show_spoilers: bool = False) -> str:
+    """Fetch comments for an episode from Trakt.
+
+    Args:
+        show_id: Trakt ID of the show
+        season: Season number
+        episode: Episode number
+        limit: Maximum number of comments to return
+        show_spoilers: Whether to show spoilers by default
+
+    Returns:
+        Information about episode comments
+    """
+    client = TraktClient()
+
+    try:
+        show = await client.get_show(show_id)
+        title = f"Show: {show.get('title', 'Unknown')} - S{season:02d}E{episode:02d}"
+    except:
+        title = f"Show ID: {show_id} - S{season:02d}E{episode:02d}"
+
+    comments = await client.get_episode_comments(show_id, season, episode, limit=limit)
+    return FormatHelper.format_comments(comments, title, show_spoilers=show_spoilers)
+
+@mcp.tool(name=TOOL_NAMES["fetch_comment"])
+async def fetch_comment(comment_id: str, show_spoilers: bool = False) -> str:
+    """Fetch a specific comment from Trakt.
+
+    Args:
+        comment_id: Trakt ID of the comment
+        show_spoilers: Whether to show spoilers by default
+
+    Returns:
+        Information about the comment
+    """
+    client = TraktClient()
+    comment = await client.get_comment(comment_id)
+    return FormatHelper.format_comment(comment, show_spoilers=show_spoilers)
+
+@mcp.tool(name=TOOL_NAMES["fetch_comment_replies"])
+async def fetch_comment_replies(comment_id: str, limit: int = DEFAULT_LIMIT, show_spoilers: bool = False) -> str:
+    """Fetch replies for a comment from Trakt.
+
+    Args:
+        comment_id: Trakt ID of the comment
+        limit: Maximum number of replies to return
+        show_spoilers: Whether to show spoilers by default
+
+    Returns:
+        Information about the comment and its replies
+    """
+    client = TraktClient()
+    comment = await client.get_comment(comment_id)
+    replies = await client.get_comment_replies(comment_id, limit=limit)
+    return FormatHelper.format_comment(comment, with_replies=True, replies=replies, show_spoilers=show_spoilers)
+
+
+@mcp.tool(name=TOOL_NAMES["search_movies"])
+async def search_movies(query: str, limit: int = DEFAULT_LIMIT) -> str:
+    """Search for movies on Trakt by title.
+
+    Args:
+        query: Search query string
+        limit: Maximum number of results to return
+
+    Returns:
+        Formatted search results
+    """
+    client = TraktClient()
+    results = await client.search_movies(query, limit)
+    return FormatHelper.format_movie_search_results(results)
+
+
 if __name__ == "__main__":
     print("Starting Trakt MCP server...")
     print("Run 'mcp dev server.py' to test with the MCP Inspector")
     print("Run 'mcp install server.py' to install in Claude Desktop")
-    mcp.run() 
+    mcp.run()

--- a/server.py
+++ b/server.py
@@ -638,13 +638,14 @@ async def fetch_watched_movies(limit: int = DEFAULT_LIMIT, period: str = "weekly
 
 
 @mcp.tool(name=TOOL_NAMES["fetch_movie_comments"])
-async def fetch_movie_comments(movie_id: str, limit: int = DEFAULT_LIMIT, show_spoilers: bool = False) -> str:
+async def fetch_movie_comments(movie_id: str, limit: int = DEFAULT_LIMIT, show_spoilers: bool = False, sort: str = "newest") -> str:
     """Fetch comments for a movie from Trakt.
 
     Args:
         movie_id: Trakt ID of the movie
         limit: Maximum number of comments to return
         show_spoilers: Whether to show spoilers by default
+        sort: How to sort comments (newest, oldest, likes, replies, highest, lowest, plays, watched)
 
     Returns:
         Information about movie comments
@@ -657,17 +658,18 @@ async def fetch_movie_comments(movie_id: str, limit: int = DEFAULT_LIMIT, show_s
     except:
         title = f"Movie ID: {movie_id}"
 
-    comments = await client.get_movie_comments(movie_id, limit=limit)
+    comments = await client.get_movie_comments(movie_id, limit=limit, sort=sort)
     return FormatHelper.format_comments(comments, title, show_spoilers=show_spoilers)
 
 @mcp.tool(name=TOOL_NAMES["fetch_show_comments"])
-async def fetch_show_comments(show_id: str, limit: int = DEFAULT_LIMIT, show_spoilers: bool = False) -> str:
+async def fetch_show_comments(show_id: str, limit: int = DEFAULT_LIMIT, show_spoilers: bool = False, sort: str = "newest") -> str:
     """Fetch comments for a show from Trakt.
 
     Args:
         show_id: Trakt ID of the show
         limit: Maximum number of comments to return
         show_spoilers: Whether to show spoilers by default
+        sort: How to sort comments (newest, oldest, likes, replies, highest, lowest, plays, watched)
 
     Returns:
         Information about show comments
@@ -680,11 +682,11 @@ async def fetch_show_comments(show_id: str, limit: int = DEFAULT_LIMIT, show_spo
     except:
         title = f"Show ID: {show_id}"
 
-    comments = await client.get_show_comments(show_id, limit=limit)
+    comments = await client.get_show_comments(show_id, limit=limit, sort=sort)
     return FormatHelper.format_comments(comments, title, show_spoilers=show_spoilers)
 
 @mcp.tool(name=TOOL_NAMES["fetch_season_comments"])
-async def fetch_season_comments(show_id: str, season: int, limit: int = DEFAULT_LIMIT, show_spoilers: bool = False) -> str:
+async def fetch_season_comments(show_id: str, season: int, limit: int = DEFAULT_LIMIT, show_spoilers: bool = False, sort: str = "newest") -> str:
     """Fetch comments for a season from Trakt.
 
     Args:
@@ -692,6 +694,7 @@ async def fetch_season_comments(show_id: str, season: int, limit: int = DEFAULT_
         season: Season number
         limit: Maximum number of comments to return
         show_spoilers: Whether to show spoilers by default
+        sort: How to sort comments (newest, oldest, likes, replies, highest, lowest, plays, watched)
 
     Returns:
         Information about season comments
@@ -704,11 +707,11 @@ async def fetch_season_comments(show_id: str, season: int, limit: int = DEFAULT_
     except:
         title = f"Show ID: {show_id} - Season {season}"
 
-    comments = await client.get_season_comments(show_id, season, limit=limit)
+    comments = await client.get_season_comments(show_id, season, limit=limit, sort=sort)
     return FormatHelper.format_comments(comments, title, show_spoilers=show_spoilers)
 
 @mcp.tool(name=TOOL_NAMES["fetch_episode_comments"])
-async def fetch_episode_comments(show_id: str, season: int, episode: int, limit: int = DEFAULT_LIMIT, show_spoilers: bool = False) -> str:
+async def fetch_episode_comments(show_id: str, season: int, episode: int, limit: int = DEFAULT_LIMIT, show_spoilers: bool = False, sort: str = "newest") -> str:
     """Fetch comments for an episode from Trakt.
 
     Args:
@@ -717,6 +720,7 @@ async def fetch_episode_comments(show_id: str, season: int, episode: int, limit:
         episode: Episode number
         limit: Maximum number of comments to return
         show_spoilers: Whether to show spoilers by default
+        sort: How to sort comments (newest, oldest, likes, replies, highest, lowest, plays, watched)
 
     Returns:
         Information about episode comments
@@ -729,7 +733,7 @@ async def fetch_episode_comments(show_id: str, season: int, episode: int, limit:
     except:
         title = f"Show ID: {show_id} - S{season:02d}E{episode:02d}"
 
-    comments = await client.get_episode_comments(show_id, season, episode, limit=limit)
+    comments = await client.get_episode_comments(show_id, season, episode, limit=limit, sort=sort)
     return FormatHelper.format_comments(comments, title, show_spoilers=show_spoilers)
 
 @mcp.tool(name=TOOL_NAMES["fetch_comment"])
@@ -748,20 +752,21 @@ async def fetch_comment(comment_id: str, show_spoilers: bool = False) -> str:
     return FormatHelper.format_comment(comment, show_spoilers=show_spoilers)
 
 @mcp.tool(name=TOOL_NAMES["fetch_comment_replies"])
-async def fetch_comment_replies(comment_id: str, limit: int = DEFAULT_LIMIT, show_spoilers: bool = False) -> str:
+async def fetch_comment_replies(comment_id: str, limit: int = DEFAULT_LIMIT, show_spoilers: bool = False, sort: str = "newest") -> str:
     """Fetch replies for a comment from Trakt.
 
     Args:
         comment_id: Trakt ID of the comment
         limit: Maximum number of replies to return
         show_spoilers: Whether to show spoilers by default
+        sort: How to sort replies (newest, oldest, likes, replies, highest, lowest, plays, watched)
 
     Returns:
         Information about the comment and its replies
     """
     client = TraktClient()
     comment = await client.get_comment(comment_id)
-    replies = await client.get_comment_replies(comment_id, limit=limit)
+    replies = await client.get_comment_replies(comment_id, limit=limit, sort=sort)
     return FormatHelper.format_comment(comment, with_replies=True, replies=replies, show_spoilers=show_spoilers)
 
 

--- a/trakt_client.py
+++ b/trakt_client.py
@@ -424,28 +424,35 @@ class TraktClient:
         })
         
     @handle_api_errors
-    async def get_movie_comments(self, movie_id: str, limit: int = DEFAULT_LIMIT, page: int = 1) -> List[Dict[str, Any]]:
-        """Get comments for a movie."""
+    async def get_movie_comments(self, movie_id: str, limit: int = DEFAULT_LIMIT, page: int = 1, sort: str = "newest") -> List[Dict[str, Any]]:
+        """Get comments for a movie.
+    
+        Args:
+            movie_id: Trakt ID of the movie
+            limit: Maximum number of comments to return
+            page: Page number for pagination
+            sort: How to sort comments (newest, oldest, likes, replies, highest, lowest, plays, watched)
+        """
         endpoint = TRAKT_ENDPOINTS["comments_movie"].replace(":id", movie_id)
-        return await self._make_request(endpoint, params={"limit": limit, "page": page})
+        return await self._make_request(endpoint, params={"limit": limit, "page": page, "sort": sort})
 
     @handle_api_errors
-    async def get_show_comments(self, show_id: str, limit: int = DEFAULT_LIMIT, page: int = 1) -> List[Dict[str, Any]]:
+    async def get_show_comments(self, show_id: str, limit: int = DEFAULT_LIMIT, page: int = 1, sort: str = "newest") -> List[Dict[str, Any]]:
         """Get comments for a show."""
         endpoint = TRAKT_ENDPOINTS["comments_show"].replace(":id", show_id)
-        return await self._make_request(endpoint, params={"limit": limit, "page": page})
+        return await self._make_request(endpoint, params={"limit": limit, "page": page, "sort": sort})
 
     @handle_api_errors
-    async def get_season_comments(self, show_id: str, season: int, limit: int = DEFAULT_LIMIT, page: int = 1) -> List[Dict[str, Any]]:
+    async def get_season_comments(self, show_id: str, season: int, limit: int = DEFAULT_LIMIT, page: int = 1, sort: str = "newest") -> List[Dict[str, Any]]:
         """Get comments for a season."""
         endpoint = TRAKT_ENDPOINTS["comments_season"].replace(":id", show_id).replace(":season", str(season))
-        return await self._make_request(endpoint, params={"limit": limit, "page": page})
+        return await self._make_request(endpoint, params={"limit": limit, "page": page, "sort": sort})
 
     @handle_api_errors
-    async def get_episode_comments(self, show_id: str, season: int, episode: int, limit: int = DEFAULT_LIMIT, page: int = 1) -> List[Dict[str, Any]]:
+    async def get_episode_comments(self, show_id: str, season: int, episode: int, limit: int = DEFAULT_LIMIT, page: int = 1, sort: str = "newest") -> List[Dict[str, Any]]:
         """Get comments for an episode."""
         endpoint = TRAKT_ENDPOINTS["comments_episode"].replace(":id", show_id).replace(":season", str(season)).replace(":episode", str(episode))
-        return await self._make_request(endpoint, params={"limit": limit, "page": page})
+        return await self._make_request(endpoint, params={"limit": limit, "page": page, "sort": sort})
 
     @handle_api_errors
     async def get_comment(self, comment_id: str) -> Dict[str, Any]:
@@ -454,10 +461,10 @@ class TraktClient:
         return await self._make_request(endpoint)
 
     @handle_api_errors
-    async def get_comment_replies(self, comment_id: str, limit: int = DEFAULT_LIMIT, page: int = 1) -> List[Dict[str, Any]]:
+    async def get_comment_replies(self, comment_id: str, limit: int = DEFAULT_LIMIT, page: int = 1, sort: str = "newest") -> List[Dict[str, Any]]:
         """Get replies for a comment."""
         endpoint = TRAKT_ENDPOINTS["comment_replies"].replace(":id", comment_id)
-        return await self._make_request(endpoint, params={"limit": limit, "page": page})
+        return await self._make_request(endpoint, params={"limit": limit, "page": page, "sort": sort})
 
     @handle_api_errors
     async def get_movie(self, movie_id: str) -> Dict[str, Any]:

--- a/trakt_client.py
+++ b/trakt_client.py
@@ -413,3 +413,60 @@ class TraktClient:
             "query": query,
             "limit": limit
         }) 
+        
+    @handle_api_errors
+    async def search_movies(self, query: str, limit: int = DEFAULT_LIMIT) -> List[Dict[str, Any]]:
+        """Search for movies on Trakt."""
+        search_endpoint = f"{TRAKT_ENDPOINTS['search']}/movie"
+        return await self._make_request(search_endpoint, params={
+            "query": query,
+            "limit": limit
+        })
+        
+    @handle_api_errors
+    async def get_movie_comments(self, movie_id: str, limit: int = DEFAULT_LIMIT, page: int = 1) -> List[Dict[str, Any]]:
+        """Get comments for a movie."""
+        endpoint = TRAKT_ENDPOINTS["comments_movie"].replace(":id", movie_id)
+        return await self._make_request(endpoint, params={"limit": limit, "page": page})
+
+    @handle_api_errors
+    async def get_show_comments(self, show_id: str, limit: int = DEFAULT_LIMIT, page: int = 1) -> List[Dict[str, Any]]:
+        """Get comments for a show."""
+        endpoint = TRAKT_ENDPOINTS["comments_show"].replace(":id", show_id)
+        return await self._make_request(endpoint, params={"limit": limit, "page": page})
+
+    @handle_api_errors
+    async def get_season_comments(self, show_id: str, season: int, limit: int = DEFAULT_LIMIT, page: int = 1) -> List[Dict[str, Any]]:
+        """Get comments for a season."""
+        endpoint = TRAKT_ENDPOINTS["comments_season"].replace(":id", show_id).replace(":season", str(season))
+        return await self._make_request(endpoint, params={"limit": limit, "page": page})
+
+    @handle_api_errors
+    async def get_episode_comments(self, show_id: str, season: int, episode: int, limit: int = DEFAULT_LIMIT, page: int = 1) -> List[Dict[str, Any]]:
+        """Get comments for an episode."""
+        endpoint = TRAKT_ENDPOINTS["comments_episode"].replace(":id", show_id).replace(":season", str(season)).replace(":episode", str(episode))
+        return await self._make_request(endpoint, params={"limit": limit, "page": page})
+
+    @handle_api_errors
+    async def get_comment(self, comment_id: str) -> Dict[str, Any]:
+        """Get a specific comment."""
+        endpoint = TRAKT_ENDPOINTS["comment"].replace(":id", comment_id)
+        return await self._make_request(endpoint)
+
+    @handle_api_errors
+    async def get_comment_replies(self, comment_id: str, limit: int = DEFAULT_LIMIT, page: int = 1) -> List[Dict[str, Any]]:
+        """Get replies for a comment."""
+        endpoint = TRAKT_ENDPOINTS["comment_replies"].replace(":id", comment_id)
+        return await self._make_request(endpoint, params={"limit": limit, "page": page})
+
+    @handle_api_errors
+    async def get_movie(self, movie_id: str) -> Dict[str, Any]:
+        """Get details for a specific movie."""
+        endpoint = f"/movies/{movie_id}"
+        return await self._make_request(endpoint)
+
+    @handle_api_errors
+    async def get_show(self, show_id: str) -> Dict[str, Any]:
+        """Get details for a specific show."""
+        endpoint = f"/shows/{show_id}"
+        return await self._make_request(endpoint)

--- a/trakt_client.py
+++ b/trakt_client.py
@@ -433,26 +433,26 @@ class TraktClient:
             page: Page number for pagination
             sort: How to sort comments (newest, oldest, likes, replies, highest, lowest, plays, watched)
         """
-        endpoint = TRAKT_ENDPOINTS["comments_movie"].replace(":id", movie_id)
-        return await self._make_request(endpoint, params={"limit": limit, "page": page, "sort": sort})
+        endpoint = TRAKT_ENDPOINTS["comments_movie"].replace(":id", movie_id).replace(":sort", sort)
+        return await self._make_request(endpoint, params={"limit": limit, "page": page})
 
     @handle_api_errors
     async def get_show_comments(self, show_id: str, limit: int = DEFAULT_LIMIT, page: int = 1, sort: str = "newest") -> List[Dict[str, Any]]:
         """Get comments for a show."""
-        endpoint = TRAKT_ENDPOINTS["comments_show"].replace(":id", show_id)
-        return await self._make_request(endpoint, params={"limit": limit, "page": page, "sort": sort})
+        endpoint = TRAKT_ENDPOINTS["comments_show"].replace(":id", show_id).replace(":sort", sort)
+        return await self._make_request(endpoint, params={"limit": limit, "page": page})
 
     @handle_api_errors
     async def get_season_comments(self, show_id: str, season: int, limit: int = DEFAULT_LIMIT, page: int = 1, sort: str = "newest") -> List[Dict[str, Any]]:
         """Get comments for a season."""
-        endpoint = TRAKT_ENDPOINTS["comments_season"].replace(":id", show_id).replace(":season", str(season))
-        return await self._make_request(endpoint, params={"limit": limit, "page": page, "sort": sort})
+        endpoint = TRAKT_ENDPOINTS["comments_season"].replace(":id", show_id).replace(":season", str(season)).replace(":sort", sort)
+        return await self._make_request(endpoint, params={"limit": limit, "page": page})
 
     @handle_api_errors
     async def get_episode_comments(self, show_id: str, season: int, episode: int, limit: int = DEFAULT_LIMIT, page: int = 1, sort: str = "newest") -> List[Dict[str, Any]]:
         """Get comments for an episode."""
-        endpoint = TRAKT_ENDPOINTS["comments_episode"].replace(":id", show_id).replace(":season", str(season)).replace(":episode", str(episode))
-        return await self._make_request(endpoint, params={"limit": limit, "page": page, "sort": sort})
+        endpoint = TRAKT_ENDPOINTS["comments_episode"].replace(":id", show_id).replace(":season", str(season)).replace(":episode", str(episode)).replace(":sort", sort)
+        return await self._make_request(endpoint, params={"limit": limit, "page": page})
 
     @handle_api_errors
     async def get_comment(self, comment_id: str) -> Dict[str, Any]:
@@ -463,8 +463,8 @@ class TraktClient:
     @handle_api_errors
     async def get_comment_replies(self, comment_id: str, limit: int = DEFAULT_LIMIT, page: int = 1, sort: str = "newest") -> List[Dict[str, Any]]:
         """Get replies for a comment."""
-        endpoint = TRAKT_ENDPOINTS["comment_replies"].replace(":id", comment_id)
-        return await self._make_request(endpoint, params={"limit": limit, "page": page, "sort": sort})
+        endpoint = TRAKT_ENDPOINTS["comment_replies"].replace(":id", comment_id).replace(":sort", sort)
+        return await self._make_request(endpoint, params={"limit": limit, "page": page})
 
     @handle_api_errors
     async def get_movie(self, movie_id: str) -> Dict[str, Any]:


### PR DESCRIPTION
Added support for viewing Trakt comments and reviews for movies, shows, seasons and episodes, with spoiler protection.

## Summary
- Added 6 new comment tools:
  - fetch_movie_comments
  - fetch_show_comments
  - fetch_season_comments
  - fetch_episode_comments
  - fetch_comment
  - fetch_comment_replies
- Added movie search functionality
- Updated documentation and configuration

## Notable Features
- Spoiler protection (hidden by default, toggleable)
- Comment sorting (newest, likes, replies, etc.)
- Viewing individual comments with their threaded replies
- Special formatting for reviews

## Example Usage
```python
# Get comments for a movie (default: newest first, no spoilers)
fetch_movie_comments(movie_id="123", limit=10)

# Get comments for a show sorted by most likes
fetch_show_comments(show_id="456", limit=10, sort="likes", show_spoilers=True)

# Get comments for a specific season sorted by highest rating
fetch_season_comments(show_id="456", season=1, limit=10, sort="highest")

# Get comments for a specific episode sorted by most replies
fetch_episode_comments(show_id="456", season=1, episode=3, limit=10, sort="replies")

# Get a specific comment
fetch_comment(comment_id="789")

# Get a comment with its replies sorted by oldest first
fetch_comment_replies(comment_id="789", limit=10, sort="oldest")
```

## Example open-webui integration
![image](https://github.com/user-attachments/assets/af2f9945-45ad-4a0a-87f7-85a45a7a2385)

