### PR TITLE
Feature: Add movie and show summary tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ search_shows(query="Breaking Bad", limit=5)
 # Get ratings for a show
 fetch_show_ratings(show_id="game-of-thrones")
 
+# Get comprehensive show summary (includes air times, production status, ratings, metadata)
+fetch_show_summary(show_id="game-of-thrones", extended=True)  # Default: comprehensive
+
+# Get basic show summary (title, year, overview, ID only)
+fetch_show_summary(show_id="game-of-thrones", extended=False)
+
 # Search for movies by title to get movie IDs and details
 search_movies(query="The Godfather", limit=5)
 ```
@@ -191,6 +197,12 @@ fetch_watched_movies(limit=10, period="weekly")
 
 # Get ratings for a movie
 fetch_movie_ratings(movie_id="tron-legacy-2010")
+
+# Get comprehensive movie summary (includes production status, ratings, genres, runtime, certification, metadata)
+fetch_movie_summary(movie_id="tron-legacy-2010", extended=True)  # Default: comprehensive
+
+# Get basic movie summary (title, year, overview, ID only)
+fetch_movie_summary(movie_id="tron-legacy-2010", extended=False)
 ```
 
 ### Authentication & User Tools
@@ -376,6 +388,9 @@ Once installed, you can ask Claude questions like:
 - "What's the rating for Game of Thrones?"
 - "Show me the rating distribution for The Godfather"
 - "How highly rated is Breaking Bad?"
+- "Get a detailed summary of Breaking Bad" (comprehensive data with air times, status, ratings)
+- "Show me details about The Godfather movie" (comprehensive data with production status, metadata)
+- "Give me basic info for Game of Thrones" (basic summary with title, year, overview only)
 
 Claude will use this MCP server to provide you with real-time data from Trakt.
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ fetch_show_ratings(show_id="game-of-thrones")
 # Get comprehensive show summary (includes air times, production status, ratings, metadata)
 fetch_show_summary(show_id="game-of-thrones", extended=True)  # Default: comprehensive
 
-# Get basic show summary (title, year, overview, ID only)
+# Get basic show summary (title, year, ID only)
 fetch_show_summary(show_id="game-of-thrones", extended=False)
 
 # Search for movies by title to get movie IDs and details
@@ -201,7 +201,7 @@ fetch_movie_ratings(movie_id="tron-legacy-2010")
 # Get comprehensive movie summary (includes production status, ratings, genres, runtime, certification, metadata)
 fetch_movie_summary(movie_id="tron-legacy-2010", extended=True)  # Default: comprehensive
 
-# Get basic movie summary (title, year, overview, ID only)
+# Get basic movie summary (title, year, ID only)
 fetch_movie_summary(movie_id="tron-legacy-2010", extended=False)
 ```
 
@@ -390,7 +390,7 @@ Once installed, you can ask Claude questions like:
 - "How highly rated is Breaking Bad?"
 - "Get a detailed summary of Breaking Bad" (comprehensive data with air times, status, ratings)
 - "Show me details about The Godfather movie" (comprehensive data with production status, metadata)
-- "Give me basic info for Game of Thrones" (basic summary with title, year, overview only)
+- "Give me basic info for Game of Thrones" (basic summary with title, year, ID only)
 
 Claude will use this MCP server to provide you with real-time data from Trakt.
 

--- a/client/movies/details.py
+++ b/client/movies/details.py
@@ -25,6 +25,20 @@ class MovieDetailsClient(BaseClient):
         return await self._make_dict_request(endpoint)
 
     @handle_api_errors
+    async def get_movie_extended(self, movie_id: str) -> dict[str, Any]:
+        """Get extended details for a specific movie.
+
+        Args:
+            movie_id: The Trakt movie ID
+
+        Returns:
+            Extended movie details data including status, enhanced overview, and metadata
+        """
+        endpoint = f"/movies/{movie_id}"
+        params = {"extended": "full"}
+        return await self._make_dict_request(endpoint, params=params)
+
+    @handle_api_errors
     async def get_movie_ratings(self, movie_id: str) -> dict[str, Any]:
         """Get ratings for a specific movie.
 

--- a/client/shows/details.py
+++ b/client/shows/details.py
@@ -25,6 +25,20 @@ class ShowDetailsClient(BaseClient):
         return await self._make_dict_request(endpoint)
 
     @handle_api_errors
+    async def get_show_extended(self, show_id: str) -> dict[str, Any]:
+        """Get extended details for a specific show.
+
+        Args:
+            show_id: The Trakt show ID
+
+        Returns:
+            Extended show details data including airs object, status, enhanced overview
+        """
+        endpoint = f"/shows/{show_id}"
+        params = {"extended": "full"}
+        return await self._make_dict_request(endpoint, params=params)
+
+    @handle_api_errors
     async def get_show_ratings(self, show_id: str) -> dict[str, Any]:
         """Get ratings for a specific show.
 

--- a/config/mcp/tools/movies.py
+++ b/config/mcp/tools/movies.py
@@ -8,4 +8,5 @@ MOVIE_TOOLS = {
     "fetch_played_movies": "fetch_played_movies",
     "fetch_watched_movies": "fetch_watched_movies",
     "fetch_movie_ratings": "fetch_movie_ratings",
+    "fetch_movie_summary": "fetch_movie_summary",
 }

--- a/config/mcp/tools/shows.py
+++ b/config/mcp/tools/shows.py
@@ -8,4 +8,5 @@ SHOW_TOOLS = {
     "fetch_played_shows": "fetch_played_shows",
     "fetch_watched_shows": "fetch_watched_shows",
     "fetch_show_ratings": "fetch_show_ratings",
+    "fetch_show_summary": "fetch_show_summary",
 }

--- a/models/formatters/movies.py
+++ b/models/formatters/movies.py
@@ -165,7 +165,7 @@ class MovieFormatters:
             movie: Movie data from Trakt API
 
         Returns:
-            Formatted markdown text with basic movie information
+            Formatted markdown text with basic movie information (title, year, ID only)
         """
         if not movie:
             return "No movie data available."
@@ -173,12 +173,10 @@ class MovieFormatters:
         title = movie.get("title", "Unknown")
         year = movie.get("year", "")
         year_str = f" ({year})" if year else ""
-        overview = movie.get("overview", "No overview available.")
         ids = movie.get("ids", {})
         trakt_id = ids.get("trakt", "Unknown")
 
         result = f"## {title}{year_str}\n\n"
-        result += f"{overview}\n\n"
         result += f"Trakt ID: {trakt_id}\n"
 
         return result

--- a/models/formatters/movies.py
+++ b/models/formatters/movies.py
@@ -156,3 +156,102 @@ class MovieFormatters:
                 result += f"| {rating}/10 | {count} | {percentage:.1f}% |\n"
 
         return result
+
+    @staticmethod
+    def format_movie_summary(movie: dict[str, Any]) -> str:
+        """Format basic movie summary data.
+
+        Args:
+            movie: Movie data from Trakt API
+
+        Returns:
+            Formatted markdown text with basic movie information
+        """
+        if not movie:
+            return "No movie data available."
+
+        title = movie.get("title", "Unknown")
+        year = movie.get("year", "")
+        year_str = f" ({year})" if year else ""
+        overview = movie.get("overview", "No overview available.")
+        ids = movie.get("ids", {})
+        trakt_id = ids.get("trakt", "Unknown")
+
+        result = f"## {title}{year_str}\n\n"
+        result += f"{overview}\n\n"
+        result += f"Trakt ID: {trakt_id}\n"
+
+        return result
+
+    @staticmethod
+    def format_movie_extended(movie: dict[str, Any]) -> str:
+        """Format extended movie details data.
+
+        Args:
+            movie: Extended movie data from Trakt API
+
+        Returns:
+            Formatted markdown text with comprehensive movie information
+        """
+        if not movie:
+            return "No movie data available."
+
+        # Basic info
+        title = movie.get("title", "Unknown")
+        year = movie.get("year", "")
+        year_str = f" ({year})" if year else ""
+        status = movie.get("status", "unknown")
+        tagline = movie.get("tagline", "")
+        overview = movie.get("overview", "No overview available.")
+        ids = movie.get("ids", {})
+        trakt_id = ids.get("trakt", "Unknown")
+
+        # Format title with status
+        result = f"## {title}{year_str} - {status.title().replace('_', ' ')}\n"
+
+        # Add tagline if available
+        if tagline:
+            result += f"*{tagline}*\n"
+
+        result += f"\n{overview}\n\n"
+
+        # Production Details
+        result += "### Production Details\n"
+        result += f"- Status: {status.replace('_', ' ')}\n"
+
+        if runtime := movie.get("runtime"):
+            result += f"- Runtime: {runtime} minutes\n"
+
+        if certification := movie.get("certification"):
+            result += f"- Certification: {certification}\n"
+
+        if released := movie.get("released"):
+            result += f"- Released: {released}\n"
+
+        if country := movie.get("country"):
+            result += f"- Country: {country.upper()}\n"
+
+        if genres := movie.get("genres"):
+            genres_str = ", ".join(genres)
+            result += f"- Genres: {genres_str}\n"
+
+        if languages := movie.get("languages"):
+            languages_str = ", ".join(languages)
+            result += f"- Languages: {languages_str}\n"
+
+        if homepage := movie.get("homepage"):
+            result += f"- Homepage: {homepage}\n"
+
+        # Ratings & Engagement
+        result += "\n### Ratings & Engagement\n"
+
+        rating = movie.get("rating", 0)
+        votes = movie.get("votes", 0)
+        result += f"- Rating: {rating:.1f}/10 ({votes} votes)\n"
+
+        if comment_count := movie.get("comment_count"):
+            result += f"- Comments: {comment_count}\n"
+
+        result += f"\nTrakt ID: {trakt_id}\n"
+
+        return result

--- a/models/formatters/shows.py
+++ b/models/formatters/shows.py
@@ -165,7 +165,7 @@ class ShowFormatters:
             show: Show data from Trakt API
 
         Returns:
-            Formatted markdown text with basic show information
+            Formatted markdown text with basic show information (title, year, ID only)
         """
         if not show:
             return "No show data available."
@@ -173,12 +173,10 @@ class ShowFormatters:
         title = show.get("title", "Unknown")
         year = show.get("year", "")
         year_str = f" ({year})" if year else ""
-        overview = show.get("overview", "No overview available.")
         ids = show.get("ids", {})
         trakt_id = ids.get("trakt", "Unknown")
 
         result = f"## {title}{year_str}\n\n"
-        result += f"{overview}\n\n"
         result += f"Trakt ID: {trakt_id}\n"
 
         return result

--- a/models/formatters/shows.py
+++ b/models/formatters/shows.py
@@ -156,3 +156,122 @@ class ShowFormatters:
                 result += f"| {rating}/10 | {count} | {percentage:.1f}% |\n"
 
         return result
+
+    @staticmethod
+    def format_show_summary(show: dict[str, Any]) -> str:
+        """Format basic show summary data.
+
+        Args:
+            show: Show data from Trakt API
+
+        Returns:
+            Formatted markdown text with basic show information
+        """
+        if not show:
+            return "No show data available."
+
+        title = show.get("title", "Unknown")
+        year = show.get("year", "")
+        year_str = f" ({year})" if year else ""
+        overview = show.get("overview", "No overview available.")
+        ids = show.get("ids", {})
+        trakt_id = ids.get("trakt", "Unknown")
+
+        result = f"## {title}{year_str}\n\n"
+        result += f"{overview}\n\n"
+        result += f"Trakt ID: {trakt_id}\n"
+
+        return result
+
+    @staticmethod
+    def format_show_extended(show: dict[str, Any]) -> str:
+        """Format extended show details data.
+
+        Args:
+            show: Extended show data from Trakt API
+
+        Returns:
+            Formatted markdown text with comprehensive show information
+        """
+        if not show:
+            return "No show data available."
+
+        # Basic info
+        title = show.get("title", "Unknown")
+        year = show.get("year", "")
+        year_str = f" ({year})" if year else ""
+        status = show.get("status", "unknown")
+        tagline = show.get("tagline", "")
+        overview = show.get("overview", "No overview available.")
+        ids = show.get("ids", {})
+        trakt_id = ids.get("trakt", "Unknown")
+
+        # Format title with status
+        result = f"## {title}{year_str} - {status.title().replace('_', ' ')}\n"
+
+        # Add tagline if available
+        if tagline:
+            result += f"*{tagline}*\n"
+
+        result += f"\n{overview}\n\n"
+
+        # Production Details
+        result += "### Production Details\n"
+        result += f"- Status: {status.replace('_', ' ')}\n"
+
+        if runtime := show.get("runtime"):
+            result += f"- Runtime: {runtime} minutes\n"
+
+        if certification := show.get("certification"):
+            result += f"- Certification: {certification}\n"
+
+        if network := show.get("network"):
+            result += f"- Network: {network}\n"
+
+        # Air time information
+        if airs := show.get("airs"):
+            day = airs.get("day", "")
+            time = airs.get("time", "")
+            timezone = airs.get("timezone", "")
+            if day or time:
+                air_time_str = "- Air Time: "
+                if day and time:
+                    air_time_str += f"{day}s at {time}"
+                elif day:
+                    air_time_str += f"{day}s"
+                elif time:
+                    air_time_str += f"at {time}"
+                if timezone:
+                    air_time_str += f" ({timezone})"
+                result += air_time_str + "\n"
+
+        if aired_episodes := show.get("aired_episodes"):
+            result += f"- Aired Episodes: {aired_episodes}\n"
+
+        if country := show.get("country"):
+            result += f"- Country: {country.upper()}\n"
+
+        if genres := show.get("genres"):
+            genres_str = ", ".join(genres)
+            result += f"- Genres: {genres_str}\n"
+
+        if languages := show.get("languages"):
+            languages_str = ", ".join(languages)
+            result += f"- Languages: {languages_str}\n"
+
+        if homepage := show.get("homepage"):
+            result += f"- Homepage: {homepage}\n"
+
+        # Ratings & Engagement
+        result += "\n### Ratings & Engagement\n"
+
+        rating = show.get("rating", 0)
+        votes = show.get("votes", 0)
+        result += f"- Rating: {rating:.1f}/10 ({votes} votes)\n"
+
+        if comment_count := show.get("comment_count"):
+            result += f"- Comments: {comment_count}\n"
+
+        result += f"\nTrakt ID: {trakt_id}\n"
+
+        return result

--- a/server/movies/tools.py
+++ b/server/movies/tools.py
@@ -138,12 +138,12 @@ async def fetch_movie_summary(movie_id: str, extended: bool = True) -> str:
     Args:
         movie_id: Trakt ID of the movie
         extended: If True, return comprehensive data with production status and metadata.
-                 If False, return basic movie information (title, year, overview, IDs).
+                 If False, return basic movie information (title, year, IDs).
 
     Returns:
         Movie information formatted as markdown. Extended mode includes production status,
         ratings, metadata, and detailed information. Basic mode includes title, year,
-        overview, and Trakt ID only.
+        and Trakt ID only.
     """
     client = MoviesClient()
 
@@ -218,7 +218,7 @@ def register_movie_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_movie_summary"],
-        description="Get movie summary from Trakt. Default behavior (extended=true): Returns comprehensive data including production status, ratings, genres, runtime, certification, and metadata. Basic mode (extended=false): Returns only title, year, overview, and Trakt ID.",
+        description="Get movie summary from Trakt. Default behavior (extended=true): Returns comprehensive data including production status, ratings, genres, runtime, certification, and metadata. Basic mode (extended=false): Returns only title, year, and Trakt ID.",
     )
     async def fetch_movie_summary_tool(movie_id: str, extended: bool = True) -> str:
         return await fetch_movie_summary(movie_id, extended)

--- a/server/movies/tools.py
+++ b/server/movies/tools.py
@@ -132,6 +132,39 @@ async def fetch_movie_ratings(movie_id: str) -> str:
         return f"Error fetching ratings for movie ID {movie_id}: {e!s}"
 
 
+async def fetch_movie_summary(movie_id: str, extended: bool = True) -> str:
+    """Fetch movie summary from Trakt.
+
+    Args:
+        movie_id: Trakt ID of the movie
+        extended: If True, return comprehensive data with production status and metadata.
+                 If False, return basic movie information (title, year, overview, IDs).
+
+    Returns:
+        Movie information formatted as markdown. Extended mode includes production status,
+        ratings, metadata, and detailed information. Basic mode includes title, year,
+        overview, and Trakt ID only.
+    """
+    client = MoviesClient()
+
+    try:
+        if extended:
+            movie = await client.get_movie_extended(movie_id)
+            # Check if the API returned an error string
+            if isinstance(movie, str):
+                return f"Error fetching movie summary for ID {movie_id}: {movie}"
+            return MovieFormatters.format_movie_extended(movie)
+        else:
+            movie = await client.get_movie(movie_id)
+            # Check if the API returned an error string
+            if isinstance(movie, str):
+                return f"Error fetching movie summary for ID {movie_id}: {movie}"
+            return MovieFormatters.format_movie_summary(movie)
+    except Exception as e:
+        logger.error(f"Error fetching movie summary: {e}")
+        return f"Error fetching movie summary for ID {movie_id}: {e!s}"
+
+
 def register_movie_tools(mcp: FastMCP) -> None:
     """Register movie tools with the MCP server."""
 
@@ -182,3 +215,10 @@ def register_movie_tools(mcp: FastMCP) -> None:
     )
     async def fetch_movie_ratings_tool(movie_id: str) -> str:
         return await fetch_movie_ratings(movie_id)
+
+    @mcp.tool(
+        name=TOOL_NAMES["fetch_movie_summary"],
+        description="Get movie summary from Trakt. Default behavior (extended=true): Returns comprehensive data including production status, ratings, genres, runtime, certification, and metadata. Basic mode (extended=false): Returns only title, year, overview, and Trakt ID.",
+    )
+    async def fetch_movie_summary_tool(movie_id: str, extended: bool = True) -> str:
+        return await fetch_movie_summary(movie_id, extended)

--- a/server/shows/tools.py
+++ b/server/shows/tools.py
@@ -129,6 +129,39 @@ async def fetch_show_ratings(show_id: str) -> str:
         return f"Error fetching ratings for show ID {show_id}: {e!s}"
 
 
+async def fetch_show_summary(show_id: str, extended: bool = True) -> str:
+    """Fetch show summary from Trakt.
+
+    Args:
+        show_id: Trakt ID of the show
+        extended: If True, return comprehensive data with air times, production status and metadata.
+                 If False, return basic show information (title, year, overview, IDs).
+
+    Returns:
+        Show information formatted as markdown. Extended mode includes air times, production status,
+        ratings, metadata, and detailed information. Basic mode includes title, year,
+        overview, and Trakt ID only.
+    """
+    client = ShowsClient()
+
+    try:
+        if extended:
+            show = await client.get_show_extended(show_id)
+            # Check if the API returned an error string
+            if isinstance(show, str):
+                return f"Error fetching show summary for ID {show_id}: {show}"
+            return ShowFormatters.format_show_extended(show)
+        else:
+            show = await client.get_show(show_id)
+            # Check if the API returned an error string
+            if isinstance(show, str):
+                return f"Error fetching show summary for ID {show_id}: {show}"
+            return ShowFormatters.format_show_summary(show)
+    except Exception as e:
+        logger.error(f"Error fetching show summary: {e}")
+        return f"Error fetching show summary for ID {show_id}: {e!s}"
+
+
 def register_show_tools(mcp: FastMCP) -> None:
     """Register show tools with the MCP server."""
 
@@ -179,3 +212,10 @@ def register_show_tools(mcp: FastMCP) -> None:
     )
     async def fetch_show_ratings_tool(show_id: str) -> str:
         return await fetch_show_ratings(show_id)
+
+    @mcp.tool(
+        name=TOOL_NAMES["fetch_show_summary"],
+        description="Get TV show summary from Trakt. Default behavior (extended=true): Returns comprehensive data including air times, production status, ratings, genres, runtime, network, and metadata. Basic mode (extended=false): Returns only title, year, overview, and Trakt ID.",
+    )
+    async def fetch_show_summary_tool(show_id: str, extended: bool = True) -> str:
+        return await fetch_show_summary(show_id, extended)

--- a/server/shows/tools.py
+++ b/server/shows/tools.py
@@ -135,12 +135,12 @@ async def fetch_show_summary(show_id: str, extended: bool = True) -> str:
     Args:
         show_id: Trakt ID of the show
         extended: If True, return comprehensive data with air times, production status and metadata.
-                 If False, return basic show information (title, year, overview, IDs).
+                 If False, return basic show information (title, year, IDs).
 
     Returns:
         Show information formatted as markdown. Extended mode includes air times, production status,
         ratings, metadata, and detailed information. Basic mode includes title, year,
-        overview, and Trakt ID only.
+        and Trakt ID only.
     """
     client = ShowsClient()
 
@@ -215,7 +215,7 @@ def register_show_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_show_summary"],
-        description="Get TV show summary from Trakt. Default behavior (extended=true): Returns comprehensive data including air times, production status, ratings, genres, runtime, network, and metadata. Basic mode (extended=false): Returns only title, year, overview, and Trakt ID.",
+        description="Get TV show summary from Trakt. Default behavior (extended=true): Returns comprehensive data including air times, production status, ratings, genres, runtime, network, and metadata. Basic mode (extended=false): Returns only title, year, and Trakt ID.",
     )
     async def fetch_show_summary_tool(show_id: str, extended: bool = True) -> str:
         return await fetch_show_summary(show_id, extended)

--- a/tests/client/movies/test_movies_client.py
+++ b/tests/client/movies/test_movies_client.py
@@ -45,3 +45,71 @@ async def test_get_movie_ratings():
         assert result["rating"] == 8.5
         assert result["votes"] == 2500
         assert "distribution" in result
+
+
+@pytest.mark.asyncio
+async def test_get_movie_extended():
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "title": "TRON: Legacy",
+        "year": 2010,
+        "ids": {
+            "trakt": 1,
+            "slug": "tron-legacy-2010",
+            "imdb": "tt1104001",
+            "tmdb": 20526,
+        },
+        "tagline": "The Game Has Changed.",
+        "overview": "Sam Flynn, the tech-savvy and daring son of Kevin Flynn, investigates his father's disappearance and is pulled into The Grid. With the help of a mysterious program named Quorra, Sam quests to stop evil dictator Clu from crossing into the real world.",
+        "released": "2010-12-16",
+        "runtime": 125,
+        "country": "us",
+        "updated_at": "2014-07-23T03:21:46.000Z",
+        "trailer": None,
+        "homepage": "http://disney.go.com/tron/",
+        "status": "released",
+        "rating": 8,
+        "votes": 111,
+        "comment_count": 92,
+        "languages": ["en"],
+        "available_translations": ["en"],
+        "genres": ["action"],
+        "certification": "PG-13",
+        "original_title": "TRON: Legacy",
+    }
+    mock_response.raise_for_status = MagicMock()
+
+    with (
+        patch("httpx.AsyncClient") as mock_client,
+        patch.dict(
+            os.environ,
+            {"TRAKT_CLIENT_ID": "test_id", "TRAKT_CLIENT_SECRET": "test_secret"},
+        ),
+    ):
+        mock_client.return_value.__aenter__.return_value.get.return_value = (
+            mock_response
+        )
+
+        client = MoviesClient()
+        result = await client.get_movie_extended("1")
+
+        # Verify the request was made with extended parameter
+        mock_client.return_value.__aenter__.return_value.get.assert_called_once()
+        call_args = mock_client.return_value.__aenter__.return_value.get.call_args
+        assert call_args[1]["params"] == {"extended": "full"}
+
+        # Verify response data
+        assert isinstance(result, dict)
+        assert result["title"] == "TRON: Legacy"
+        assert result["year"] == 2010
+        assert result["status"] == "released"
+        assert result["tagline"] == "The Game Has Changed."
+        assert result["certification"] == "PG-13"
+        assert result["runtime"] == 125
+        assert result["country"] == "us"
+        assert result["homepage"] == "http://disney.go.com/tron/"
+        assert result["original_title"] == "TRON: Legacy"
+        assert "overview" in result
+        assert "released" in result
+        assert "languages" in result
+        assert "genres" in result

--- a/tests/models/formatters/test_movies_formatter.py
+++ b/tests/models/formatters/test_movies_formatter.py
@@ -65,13 +65,11 @@ class TestMovieFormatters:
         movie_data = {
             "title": "The Matrix",
             "year": 1999,
-            "overview": "A computer hacker learns about the true nature of reality.",
             "ids": {"trakt": 12345},
         }
         result = MovieFormatters.format_movie_summary(movie_data)
         assert isinstance(result, str)
         assert "## The Matrix (1999)" in result
-        assert "A computer hacker learns about the true nature of reality." in result
         assert "Trakt ID: 12345" in result
 
     def test_format_movie_summary_with_missing_data(self) -> None:
@@ -80,7 +78,6 @@ class TestMovieFormatters:
         result = MovieFormatters.format_movie_summary(movie_data)
         assert isinstance(result, str)
         assert "Test Movie" in result
-        assert "No overview available." in result
 
     def test_format_movie_summary_empty_data(self) -> None:
         """Test format_movie_summary with empty data."""

--- a/tests/models/formatters/test_movies_formatter.py
+++ b/tests/models/formatters/test_movies_formatter.py
@@ -40,6 +40,8 @@ class TestMovieFormatters:
             "format_favorited_movies",
             "format_played_movies",
             "format_watched_movies",
+            "format_movie_summary",
+            "format_movie_extended",
         ]
 
         for method_name in expected_methods:
@@ -57,3 +59,91 @@ class TestMovieFormatters:
                     assert isinstance(attr, staticmethod), (
                         f"Method {attr_name} should be static"
                     )
+
+    def test_format_movie_summary(self) -> None:
+        """Test format_movie_summary with basic movie data."""
+        movie_data = {
+            "title": "The Matrix",
+            "year": 1999,
+            "overview": "A computer hacker learns about the true nature of reality.",
+            "ids": {"trakt": 12345},
+        }
+        result = MovieFormatters.format_movie_summary(movie_data)
+        assert isinstance(result, str)
+        assert "## The Matrix (1999)" in result
+        assert "A computer hacker learns about the true nature of reality." in result
+        assert "Trakt ID: 12345" in result
+
+    def test_format_movie_summary_with_missing_data(self) -> None:
+        """Test format_movie_summary with missing fields."""
+        movie_data = {"title": "Test Movie"}
+        result = MovieFormatters.format_movie_summary(movie_data)
+        assert isinstance(result, str)
+        assert "Test Movie" in result
+        assert "No overview available." in result
+
+    def test_format_movie_summary_empty_data(self) -> None:
+        """Test format_movie_summary with empty data."""
+        result = MovieFormatters.format_movie_summary({})
+        assert isinstance(result, str)
+        assert "No movie data available." in result
+
+    def test_format_movie_extended(self) -> None:
+        """Test format_movie_extended with comprehensive movie data."""
+        movie_data = {
+            "title": "TRON: Legacy",
+            "year": 2010,
+            "ids": {"trakt": 1},
+            "tagline": "The Game Has Changed.",
+            "overview": "Sam Flynn investigates his father's disappearance.",
+            "released": "2010-12-16",
+            "runtime": 125,
+            "country": "us",
+            "status": "released",
+            "rating": 8.0,
+            "votes": 111,
+            "comment_count": 92,
+            "languages": ["en"],
+            "genres": ["action", "sci-fi"],
+            "certification": "PG-13",
+            "homepage": "http://disney.go.com/tron/",
+        }
+        result = MovieFormatters.format_movie_extended(movie_data)
+        assert isinstance(result, str)
+        assert "## TRON: Legacy (2010) - Released" in result
+        assert "*The Game Has Changed.*" in result
+        assert "Sam Flynn investigates his father's disappearance." in result
+        assert "- Status: released" in result
+        assert "- Runtime: 125 minutes" in result
+        assert "- Certification: PG-13" in result
+        assert "- Released: 2010-12-16" in result
+        assert "- Country: US" in result
+        assert "- Genres: action, sci-fi" in result
+        assert "- Languages: en" in result
+        assert "- Homepage: http://disney.go.com/tron/" in result
+        assert "- Rating: 8.0/10 (111 votes)" in result
+        assert "- Comments: 92" in result
+        assert "Trakt ID: 1" in result
+
+    def test_format_movie_extended_with_partial_data(self) -> None:
+        """Test format_movie_extended with partial data."""
+        movie_data = {
+            "title": "Test Movie",
+            "year": 2023,
+            "status": "in_production",
+            "rating": 7.5,
+            "votes": 50,
+        }
+        result = MovieFormatters.format_movie_extended(movie_data)
+        assert isinstance(result, str)
+        assert "## Test Movie (2023) - In Production" in result
+        assert "- Status: in production" in result
+        assert "- Rating: 7.5/10 (50 votes)" in result
+        # Ensure optional fields don't appear
+        assert "- Runtime:" not in result
+        assert "- Certification:" not in result
+        assert "- Released:" not in result
+        assert "- Genres:" not in result
+        assert "- Languages:" not in result
+        assert "- Homepage:" not in result
+        assert "- Comments:" not in result

--- a/tests/models/formatters/test_shows_formatter.py
+++ b/tests/models/formatters/test_shows_formatter.py
@@ -40,6 +40,8 @@ class TestShowFormatters:
             "format_favorited_shows",
             "format_played_shows",
             "format_watched_shows",
+            "format_show_summary",
+            "format_show_extended",
         ]
 
         for method_name in expected_methods:
@@ -57,3 +59,110 @@ class TestShowFormatters:
                     assert isinstance(attr, staticmethod), (
                         f"Method {attr_name} should be static"
                     )
+
+    def test_format_show_summary(self) -> None:
+        """Test format_show_summary with basic show data."""
+        show_data = {
+            "title": "Breaking Bad",
+            "year": 2008,
+            "overview": "A high school chemistry teacher turned meth producer.",
+            "ids": {"trakt": 54321},
+        }
+        result = ShowFormatters.format_show_summary(show_data)
+        assert isinstance(result, str)
+        assert "## Breaking Bad (2008)" in result
+        assert "A high school chemistry teacher turned meth producer." in result
+        assert "Trakt ID: 54321" in result
+
+    def test_format_show_summary_with_missing_data(self) -> None:
+        """Test format_show_summary with missing fields."""
+        show_data = {"title": "Test Show"}
+        result = ShowFormatters.format_show_summary(show_data)
+        assert isinstance(result, str)
+        assert "Test Show" in result
+        assert "No overview available." in result
+
+    def test_format_show_summary_empty_data(self) -> None:
+        """Test format_show_summary with empty data."""
+        result = ShowFormatters.format_show_summary({})
+        assert isinstance(result, str)
+        assert "No show data available." in result
+
+    def test_format_show_extended(self) -> None:
+        """Test format_show_extended with comprehensive show data."""
+        show_data = {
+            "title": "Game of Thrones",
+            "year": 2011,
+            "ids": {"trakt": 1},
+            "tagline": "Winter Is Coming",
+            "overview": "An epic fantasy drama series.",
+            "first_aired": "2011-04-18T01:00:00.000Z",
+            "airs": {"day": "Sunday", "time": "21:00", "timezone": "America/New_York"},
+            "runtime": 60,
+            "certification": "TV-MA",
+            "network": "HBO",
+            "country": "us",
+            "status": "returning_series",
+            "rating": 9.0,
+            "votes": 111,
+            "comment_count": 92,
+            "languages": ["en"],
+            "genres": ["drama", "fantasy"],
+            "aired_episodes": 50,
+            "homepage": "http://www.hbo.com/game-of-thrones/",
+        }
+        result = ShowFormatters.format_show_extended(show_data)
+        assert isinstance(result, str)
+        assert "## Game of Thrones (2011) - Returning Series" in result
+        assert "*Winter Is Coming*" in result
+        assert "An epic fantasy drama series." in result
+        assert "- Status: returning series" in result
+        assert "- Runtime: 60 minutes" in result
+        assert "- Certification: TV-MA" in result
+        assert "- Network: HBO" in result
+        assert "- Air Time: Sundays at 21:00 (America/New_York)" in result
+        assert "- Aired Episodes: 50" in result
+        assert "- Country: US" in result
+        assert "- Genres: drama, fantasy" in result
+        assert "- Languages: en" in result
+        assert "- Homepage: http://www.hbo.com/game-of-thrones/" in result
+        assert "- Rating: 9.0/10 (111 votes)" in result
+        assert "- Comments: 92" in result
+        assert "Trakt ID: 1" in result
+
+    def test_format_show_extended_with_partial_data(self) -> None:
+        """Test format_show_extended with partial data."""
+        show_data = {
+            "title": "Test Show",
+            "year": 2023,
+            "status": "pilot",
+            "rating": 7.5,
+            "votes": 50,
+            "airs": {"day": "Monday"},
+        }
+        result = ShowFormatters.format_show_extended(show_data)
+        assert isinstance(result, str)
+        assert "## Test Show (2023) - Pilot" in result
+        assert "- Status: pilot" in result
+        assert "- Air Time: Mondays" in result
+        assert "- Rating: 7.5/10 (50 votes)" in result
+        # Ensure optional fields don't appear
+        assert "- Runtime:" not in result
+        assert "- Certification:" not in result
+        assert "- Network:" not in result
+        assert "- Aired Episodes:" not in result
+        assert "- Genres:" not in result
+        assert "- Languages:" not in result
+        assert "- Homepage:" not in result
+        assert "- Comments:" not in result
+
+    def test_format_show_extended_with_partial_airs(self) -> None:
+        """Test format_show_extended with partial airs data."""
+        show_data = {
+            "title": "Test Show",
+            "year": 2023,
+            "airs": {"time": "20:00", "timezone": "UTC"},
+        }
+        result = ShowFormatters.format_show_extended(show_data)
+        assert isinstance(result, str)
+        assert "- Air Time: at 20:00 (UTC)" in result

--- a/tests/models/formatters/test_shows_formatter.py
+++ b/tests/models/formatters/test_shows_formatter.py
@@ -65,13 +65,11 @@ class TestShowFormatters:
         show_data = {
             "title": "Breaking Bad",
             "year": 2008,
-            "overview": "A high school chemistry teacher turned meth producer.",
             "ids": {"trakt": 54321},
         }
         result = ShowFormatters.format_show_summary(show_data)
         assert isinstance(result, str)
         assert "## Breaking Bad (2008)" in result
-        assert "A high school chemistry teacher turned meth producer." in result
         assert "Trakt ID: 54321" in result
 
     def test_format_show_summary_with_missing_data(self) -> None:
@@ -80,7 +78,6 @@ class TestShowFormatters:
         result = ShowFormatters.format_show_summary(show_data)
         assert isinstance(result, str)
         assert "Test Show" in result
-        assert "No overview available." in result
 
     def test_format_show_summary_empty_data(self) -> None:
         """Test format_show_summary with empty data."""

--- a/tests/server/movies/test_movies_tools.py
+++ b/tests/server/movies/test_movies_tools.py
@@ -219,7 +219,6 @@ async def test_fetch_movie_summary_basic():
     sample_movie = {
         "title": "The Matrix",
         "year": 1999,
-        "overview": "A computer hacker learns about the true nature of reality.",
         "ids": {"trakt": 12345},
     }
 
@@ -233,7 +232,6 @@ async def test_fetch_movie_summary_basic():
         result = await fetch_movie_summary(movie_id="12345", extended=False)
 
         assert "## The Matrix (1999)" in result
-        assert "A computer hacker learns about the true nature of reality." in result
         assert "Trakt ID: 12345" in result
         # Should not contain extended data
         assert "- Status:" not in result

--- a/tests/server/movies/test_movies_tools.py
+++ b/tests/server/movies/test_movies_tools.py
@@ -9,7 +9,11 @@ import pytest
 sys.path.append(str(Path(__file__).parent.parent.parent.parent))
 
 from server.comments.tools import fetch_movie_comments
-from server.movies.tools import fetch_movie_ratings, fetch_trending_movies
+from server.movies.tools import (
+    fetch_movie_ratings,
+    fetch_movie_summary,
+    fetch_trending_movies,
+)
 
 
 @pytest.mark.asyncio
@@ -158,3 +162,152 @@ async def test_fetch_movie_comments_string_error_handling():
         mock_client.get_movie_comments.assert_called_once_with(
             "1", limit=5, sort="newest"
         )
+
+
+@pytest.mark.asyncio
+async def test_fetch_movie_summary_extended():
+    """Test fetching movie summary with extended data (default)."""
+    sample_movie = {
+        "title": "The Matrix",
+        "year": 1999,
+        "ids": {"trakt": 12345},
+        "tagline": "The future is not set.",
+        "overview": "A computer hacker learns about the true nature of reality.",
+        "released": "1999-03-31",
+        "runtime": 136,
+        "country": "us",
+        "status": "released",
+        "rating": 8.7,
+        "votes": 150,
+        "comment_count": 75,
+        "languages": ["en"],
+        "genres": ["action", "sci-fi"],
+        "certification": "R",
+        "homepage": "http://www.thematrix.com/",
+    }
+
+    with patch("server.movies.tools.MoviesClient") as mock_client_class:
+        mock_client = mock_client_class.return_value
+
+        movie_future: asyncio.Future[Any] = asyncio.Future()
+        movie_future.set_result(sample_movie)
+        mock_client.get_movie_extended.return_value = movie_future
+
+        result = await fetch_movie_summary(movie_id="12345")
+
+        assert "## The Matrix (1999) - Released" in result
+        assert "*The future is not set.*" in result
+        assert "A computer hacker learns about the true nature of reality." in result
+        assert "- Status: released" in result
+        assert "- Runtime: 136 minutes" in result
+        assert "- Certification: R" in result
+        assert "- Released: 1999-03-31" in result
+        assert "- Country: US" in result
+        assert "- Genres: action, sci-fi" in result
+        assert "- Languages: en" in result
+        assert "- Homepage: http://www.thematrix.com/" in result
+        assert "- Rating: 8.7/10 (150 votes)" in result
+        assert "- Comments: 75" in result
+        assert "Trakt ID: 12345" in result
+
+        mock_client.get_movie_extended.assert_called_once_with("12345")
+
+
+@pytest.mark.asyncio
+async def test_fetch_movie_summary_basic():
+    """Test fetching movie summary with basic data only."""
+    sample_movie = {
+        "title": "The Matrix",
+        "year": 1999,
+        "overview": "A computer hacker learns about the true nature of reality.",
+        "ids": {"trakt": 12345},
+    }
+
+    with patch("server.movies.tools.MoviesClient") as mock_client_class:
+        mock_client = mock_client_class.return_value
+
+        movie_future: asyncio.Future[Any] = asyncio.Future()
+        movie_future.set_result(sample_movie)
+        mock_client.get_movie.return_value = movie_future
+
+        result = await fetch_movie_summary(movie_id="12345", extended=False)
+
+        assert "## The Matrix (1999)" in result
+        assert "A computer hacker learns about the true nature of reality." in result
+        assert "Trakt ID: 12345" in result
+        # Should not contain extended data
+        assert "- Status:" not in result
+        assert "- Runtime:" not in result
+        assert "- Certification:" not in result
+
+        mock_client.get_movie.assert_called_once_with("12345")
+
+
+@pytest.mark.asyncio
+async def test_fetch_movie_summary_extended_error():
+    """Test fetching movie summary with extended mode error."""
+    with patch("server.movies.tools.MoviesClient") as mock_client_class:
+        mock_client = mock_client_class.return_value
+
+        future: asyncio.Future[Any] = asyncio.Future()
+        future.set_exception(Exception("API error"))
+        mock_client.get_movie_extended.return_value = future
+
+        result = await fetch_movie_summary(movie_id="12345")
+
+        assert "Error fetching movie summary for ID 12345" in result
+        mock_client.get_movie_extended.assert_called_once_with("12345")
+
+
+@pytest.mark.asyncio
+async def test_fetch_movie_summary_basic_error():
+    """Test fetching movie summary with basic mode error."""
+    with patch("server.movies.tools.MoviesClient") as mock_client_class:
+        mock_client = mock_client_class.return_value
+
+        future: asyncio.Future[Any] = asyncio.Future()
+        future.set_exception(Exception("API error"))
+        mock_client.get_movie.return_value = future
+
+        result = await fetch_movie_summary(movie_id="12345", extended=False)
+
+        assert "Error fetching movie summary for ID 12345" in result
+        mock_client.get_movie.assert_called_once_with("12345")
+
+
+@pytest.mark.asyncio
+async def test_fetch_movie_summary_extended_string_error():
+    """Test fetching movie summary with extended mode string error response."""
+    with patch("server.movies.tools.MoviesClient") as mock_client_class:
+        mock_client = mock_client_class.return_value
+
+        future: asyncio.Future[Any] = asyncio.Future()
+        future.set_result("Error: Movie not found")
+        mock_client.get_movie_extended.return_value = future
+
+        result = await fetch_movie_summary(movie_id="12345")
+
+        assert (
+            "Error fetching movie summary for ID 12345: Error: Movie not found"
+            in result
+        )
+        mock_client.get_movie_extended.assert_called_once_with("12345")
+
+
+@pytest.mark.asyncio
+async def test_fetch_movie_summary_basic_string_error():
+    """Test fetching movie summary with basic mode string error response."""
+    with patch("server.movies.tools.MoviesClient") as mock_client_class:
+        mock_client = mock_client_class.return_value
+
+        future: asyncio.Future[Any] = asyncio.Future()
+        future.set_result("Error: Movie not found")
+        mock_client.get_movie.return_value = future
+
+        result = await fetch_movie_summary(movie_id="12345", extended=False)
+
+        assert (
+            "Error fetching movie summary for ID 12345: Error: Movie not found"
+            in result
+        )
+        mock_client.get_movie.assert_called_once_with("12345")

--- a/tests/server/shows/test_shows_tools.py
+++ b/tests/server/shows/test_shows_tools.py
@@ -402,7 +402,6 @@ async def test_fetch_show_summary_basic():
     sample_show = {
         "title": "Breaking Bad",
         "year": 2008,
-        "overview": "A high school chemistry teacher turned meth producer.",
         "ids": {"trakt": 54321},
     }
 
@@ -416,7 +415,6 @@ async def test_fetch_show_summary_basic():
         result = await fetch_show_summary(show_id="54321", extended=False)
 
         assert "## Breaking Bad (2008)" in result
-        assert "A high school chemistry teacher turned meth producer." in result
         assert "Trakt ID: 54321" in result
         # Should not contain extended data
         assert "- Status:" not in result


### PR DESCRIPTION
- Implement fetch_movie_summary and fetch_show_summary with extended parameter support
- Add get_movie_extended() and get_show_extended() client methods for enhanced API data
- Create dedicated extended formatters for comprehensive summary display
- Support both extended (default) and basic modes for flexible data retrieval
- Include production status, air times, ratings, and metadata in extended summaries
- Maintain backwards compatibility with existing basic methods
- Add comprehensive test coverage for new functionality

Examples:
<img width="1610" height="1334" alt="image" src="https://github.com/user-attachments/assets/af3cbd3c-3914-44d5-b708-7bf1040b7033" />

<img width="1610" height="1358" alt="image" src="https://github.com/user-attachments/assets/67f9b247-8594-45fc-be33-831967cd9763" />

🤖 Generated with [Claude Code](https://claude.ai/code)