### PR TITLE
Add Dockerfile for running Trakt MCP server with MCP Proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# mcp-proxy + Trakt MCP server (SSE -> stdio)
+FROM ghcr.io/sparfenyuk/mcp-proxy:latest
+
+# Install Python and tools (base image is Alpine)
+RUN apk add --no-cache \
+    python3 \
+    py3-pip \
+    git \
+    curl
+
+# Workdir
+WORKDIR /app
+
+# Clone Trakt MCP server
+RUN git clone https://github.com/wwiens/trakt_mcpserver.git trakt-server
+
+# Install Python dependencies
+WORKDIR /app/trakt-server
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+# Back to root workdir
+WORKDIR /app
+
+# Trakt credentials (override at runtime)
+ENV TRAKT_CLIENT_ID=""
+ENV TRAKT_CLIENT_SECRET=""
+
+# Expose SSE port
+EXPOSE 8080
+
+# Run as: SSE proxy on 0.0.0.0:8080 -> spawn local stdio server
+# --port fixes the listening port (default would be random if omitted)
+# --pass-environment forwards TRAKT_* vars to the child process
+# `--` separates proxy args from child args
+CMD ["--host", "0.0.0.0", "--port", "8080", "--pass-environment", "--", "python3", "/app/trakt-server/server.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  trakt_mcpserver:
+    build: .
+    container_name: trakt_mcpserver
+    ports:
+      - 8080:8080
+    environment:
+      - TRAKT_CLIENT_ID=${TRAKT_CLIENT_ID:-""}
+      - TRAKT_CLIENT_SECRET=${TRAKT_CLIENT_SECRET:-""}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s


### PR DESCRIPTION
This PR introduces a Dockerfile to build and run the Trakt MCP server inside a container, using the [mcp-proxy](https://github.com/sparfenyuk/mcp-proxy) as an SSE-to-stdio bridge, allowing to use the Trakt MCP server via HTTP (SSE protocol).

Key points:

- Based on ghcr.io/sparfenyuk/mcp-proxy:latest (Alpine).
- Installs Python, pip, and required dependencies for the Trakt MCP server.
- Clones the trakt_mcpserver source into the container.
- Configures environment variables for TRAKT_CLIENT_ID and TRAKT_CLIENT_SECRET.
- Exposes port 8080 and correctly forwards --host and --port flags to the proxy.
- Uses --pass-environment to propagate credentials to the server.
- Supports running via docker run or docker-compose.

Works with n8n:
<img width="1874" height="837" alt="image" src="https://github.com/user-attachments/assets/ebc1d728-cbb4-4db6-80f1-20c8209baa60" />
