### PR TITLE
docker: push to ghcr on commit to main

### DIFF
--- a/.github/workflows/push_ghcr.yml
+++ b/.github/workflows/push_ghcr.yml
@@ -1,0 +1,31 @@
+name: Build and Push to GHCR
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/trakt_mcpserver:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository_owner }}/${{ github.event.repository.name }}


### PR DESCRIPTION
Adds GitHub Action workflow to automatically build and publish Docker images to GitHub Container Registry (GHCR) when code is pushed to the main branch.