### PR TITLE
fix: isolate test auth tokens and add 401 refresh-and-retry

### DIFF
--- a/server/sync/tools.py
+++ b/server/sync/tools.py
@@ -784,8 +784,7 @@ def register_sync_tools(
     @mcp.tool(
         name=SYNC_TOOLS["add_user_ratings"],
         description=(
-            "Add new ratings for the authenticated user. "
-            "Requires OAuth authentication."
+            "Add new ratings for the authenticated user. Requires OAuth authentication."
         ),
     )
     async def add_user_ratings_tool(
@@ -806,8 +805,7 @@ def register_sync_tools(
     @mcp.tool(
         name=SYNC_TOOLS["remove_user_ratings"],
         description=(
-            "Remove ratings for the authenticated user. "
-            "Requires OAuth authentication."
+            "Remove ratings for the authenticated user. Requires OAuth authentication."
         ),
     )
     async def remove_user_ratings_tool(

--- a/tests/client/auth/test_auth_client.py
+++ b/tests/client/auth/test_auth_client.py
@@ -66,8 +66,10 @@ async def test_auth_client_load_auth_token_success(monkeypatch: pytest.MonkeyPat
 async def test_auth_client_load_auth_token_file_not_exists(
     monkeypatch: pytest.MonkeyPatch,
 ):
+    from client.auth.client import AUTH_TOKEN_FILE
+
     def path_exists_side_effect(path: str) -> bool:
-        return path != "auth_token.json"
+        return path != AUTH_TOKEN_FILE
 
     monkeypatch.setenv("TRAKT_CLIENT_ID", "test_id")
     monkeypatch.setenv("TRAKT_CLIENT_SECRET", "test_secret")
@@ -207,11 +209,13 @@ async def test_auth_client_get_device_token_success(monkeypatch: pytest.MonkeyPa
         assert result.refresh_token == "refresh_token_123"
 
         # Verify that os.open was called with secure permissions on temp file
+        from client.auth.client import AUTH_TOKEN_FILE
+
         mock_os_open.assert_called_once_with(
-            "auth_token.json.tmp", os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600
+            f"{AUTH_TOKEN_FILE}.tmp", os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600
         )
         # Verify atomic replace was called
-        mock_replace.assert_called_once_with("auth_token.json.tmp", "auth_token.json")
+        mock_replace.assert_called_once_with(f"{AUTH_TOKEN_FILE}.tmp", AUTH_TOKEN_FILE)
         # Verify that file write was called
         assert mock_fdopen.return_value.write.called
         # Optionally assert that JSON was written at least once
@@ -244,13 +248,16 @@ def test_clear_auth_token(monkeypatch: pytest.MonkeyPatch):
         assert result is True
         assert client.auth_token is None
         assert "Authorization" not in client.headers
-        mock_remove.assert_called_once_with("auth_token.json")
+        from client.auth.client import AUTH_TOKEN_FILE
+
+        mock_remove.assert_called_once_with(AUTH_TOKEN_FILE)
 
 
 def test_clear_auth_token_no_file(monkeypatch: pytest.MonkeyPatch):
+    from client.auth.client import AUTH_TOKEN_FILE
+
     def path_exists_side_effect(path: str) -> bool:
-        # Only return False for auth_token.json
-        return path != "auth_token.json"
+        return path != AUTH_TOKEN_FILE
 
     monkeypatch.setenv("TRAKT_CLIENT_ID", "test_id")
     monkeypatch.setenv("TRAKT_CLIENT_SECRET", "test_secret")
@@ -374,12 +381,13 @@ def test_clear_auth_token_concurrent_calls(monkeypatch: pytest.MonkeyPatch) -> N
 
 def test_clear_auth_token_already_none(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that clear_auth_token returns False when token is already None."""
+    from client.auth.client import AUTH_TOKEN_FILE
+
     monkeypatch.setenv("TRAKT_CLIENT_ID", "test_id")
     monkeypatch.setenv("TRAKT_CLIENT_SECRET", "test_secret")
 
     def path_exists_side_effect(path: str) -> bool:
-        # Return False for auth_token.json to skip loading
-        return path != "auth_token.json"
+        return path != AUTH_TOKEN_FILE
 
     with (
         patch("dotenv.load_dotenv"),

--- a/tests/client/auth/test_auth_client.py
+++ b/tests/client/auth/test_auth_client.py
@@ -624,8 +624,7 @@ async def test_refresh_access_token_invalid_grant_clears_token(
 async def test_ensure_authenticated_valid_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test that ensure_authenticated returns True for valid token without refreshing.
-    """
+    """Test ensure_authenticated returns True for valid token."""
     current_time = int(time.time())
 
     monkeypatch.setenv("TRAKT_CLIENT_ID", "test_id")

--- a/tests/client/auth/test_auth_flow.py
+++ b/tests/client/auth/test_auth_flow.py
@@ -79,7 +79,7 @@ async def test_complete_device_auth_flow():
 
         assert client.is_authenticated() is True
 
-        # Verify file was written via os.open (secure permissions) and atomically replaced
+        # Verify secure file write and atomic replace
         assert mock_os_open.called
         assert mock_replace.called
 

--- a/tests/client/auth/test_auth_flow.py
+++ b/tests/client/auth/test_auth_flow.py
@@ -1,6 +1,6 @@
 import os
 import time
-from unittest.mock import AsyncMock, MagicMock, mock_open, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -43,8 +43,9 @@ async def test_complete_device_auth_flow():
 
     with (
         patch("httpx.AsyncClient") as mock_client,
-        patch("builtins.open", mock_open()) as mock_file,
-        patch("json.dumps", return_value="{}"),
+        patch("os.open") as mock_os_open,
+        patch("os.fdopen") as mock_fdopen,
+        patch("os.replace") as mock_replace,
         patch.dict(
             os.environ,
             {"TRAKT_CLIENT_ID": "test_id", "TRAKT_CLIENT_SECRET": "test_secret"},
@@ -56,6 +57,13 @@ async def test_complete_device_auth_flow():
         mock_instance.get = AsyncMock()
         mock_instance.aclose = AsyncMock()
         mock_client.return_value = mock_instance
+
+        # Set up the os.open and os.fdopen mocks
+        mock_os_open.return_value = 3
+        mock_file_obj = MagicMock()
+        mock_fdopen.return_value = mock_file_obj
+        mock_fdopen.return_value.__enter__ = mock_file_obj
+        mock_fdopen.return_value.__exit__ = MagicMock(return_value=None)
 
         client = AuthClient()
 
@@ -71,7 +79,9 @@ async def test_complete_device_auth_flow():
 
         assert client.is_authenticated() is True
 
-        assert mock_file.called
+        # Verify file was written via os.open (secure permissions) and atomically replaced
+        assert mock_os_open.called
+        assert mock_replace.called
 
 
 # Test removed as refresh_token method doesn't exist in AuthClient

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,23 @@ if project_root_pathlib not in sys.path:
     sys.path.insert(0, project_root_pathlib)
 
 
+@pytest.fixture(autouse=True, scope="session")
+def _isolate_auth_token_file(  # pyright: ignore[reportUnusedFunction]
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Generator[None, None, None]:
+    """Prevent tests from reading/writing the real auth_token.json.
+
+    Patches AUTH_TOKEN_FILE to a temp path so no test can accidentally
+    overwrite the user's real OAuth token.
+    """
+    safe_token_path = str(tmp_path_factory.mktemp("auth") / "auth_token.json")
+    with (
+        patch.dict(os.environ, {"TRAKT_AUTH_TOKEN_PATH": safe_token_path}),
+        patch("client.auth.client.AUTH_TOKEN_FILE", safe_token_path),
+    ):
+        yield
+
+
 @pytest.fixture
 def trakt_env() -> Generator[None, None, None]:
     """Patch environment variables with test Trakt credentials.

--- a/tests/integration/test_error_propagation.py
+++ b/tests/integration/test_error_propagation.py
@@ -42,8 +42,7 @@ class MockHttpErrorFactory(Protocol):
 
 
 class TestErrorPropagationThroughStack:
-    """Test error propagation through the complete Client → Tool → MCP → Response stack.
-    """
+    """Test error propagation through the full stack."""
 
     @pytest.fixture(autouse=True)
     def setup_context(self):

--- a/tests/models/formatters/test_videos_formatter.py
+++ b/tests/models/formatters/test_videos_formatter.py
@@ -452,10 +452,7 @@ class TestVideoFormatters:
         assert "### Official Trailer" in result
 
         # Check iframe embed
-        assert (
-            _IFRAME_INSTRUCTION
-            in result
-        )
+        assert _IFRAME_INSTRUCTION in result
         assert "<iframe" in result
         assert "https://www.youtube.com/embed/ZbsiKjVAV28" in result
         assert 'width="560"' in result
@@ -493,10 +490,7 @@ class TestVideoFormatters:
         )
 
         # Should not contain iframe or instructional text
-        assert (
-            _IFRAME_INSTRUCTION
-            not in result
-        )
+        assert _IFRAME_INSTRUCTION not in result
         assert "<iframe" not in result
 
         # Should contain simple link
@@ -580,10 +574,7 @@ class TestVideoFormatters:
         )
 
         # Should not contain iframe for non-YouTube
-        assert (
-            _IFRAME_INSTRUCTION
-            not in result
-        )
+        assert _IFRAME_INSTRUCTION not in result
         assert "<iframe" not in result
 
         # Should contain simple link even with embed_markdown=True
@@ -714,10 +705,7 @@ class TestVideoFormatters:
         )
 
         # Should fallback to simple link, not iframe
-        assert (
-            _IFRAME_INSTRUCTION
-            not in result
-        )
+        assert _IFRAME_INSTRUCTION not in result
         assert "<iframe" not in result
         assert "[▶️ Watch on YouTube]" in result
         assert "https://youtube.com/watch?v=INVALID" in result

--- a/tests/models/test_media.py
+++ b/tests/models/test_media.py
@@ -58,8 +58,7 @@ class TestTraktShow:
                 tmdb=1396,
             ),
             overview=(
-                "A high school chemistry teacher diagnosed"
-                " with inoperable lung cancer."
+                "A high school chemistry teacher diagnosed with inoperable lung cancer."
             ),
         )
 
@@ -161,8 +160,7 @@ class TestTraktMovie:
                 tmdb=27205,
             ),
             overview=(
-                "A thief who steals corporate secrets"
-                " through dream-sharing technology."
+                "A thief who steals corporate secrets through dream-sharing technology."
             ),
         )
 

--- a/tests/models/test_user_rating_identifier.py
+++ b/tests/models/test_user_rating_identifier.py
@@ -124,8 +124,7 @@ class TestUserRatingIdentifierValidation:
         assert "Rating item must include either an identifier" in error_msg
 
     def test_invalid_empty_strings_no_title_year(self) -> None:
-        """Test validation error when identifiers are empty strings and no title/year.
-        """
+        """Test validation error with empty string IDs."""
         with pytest.raises(ValidationError) as exc_info:
             UserRatingIdentifier(trakt_id="", imdb_id="", tmdb_id="")
 

--- a/tests/models/test_user_rating_request_item.py
+++ b/tests/models/test_user_rating_request_item.py
@@ -135,8 +135,7 @@ class TestUserRatingRequestItemValidation:
         assert "Rating item must include either an identifier" in error_msg
 
     def test_invalid_empty_strings_no_title_year(self) -> None:
-        """Test validation error when identifiers are empty strings and no title/year.
-        """
+        """Test validation error with empty string IDs."""
         with pytest.raises(ValidationError) as exc_info:
             UserRatingRequestItem(rating=8, trakt_id="", imdb_id="", tmdb_id="")
 

--- a/tests/models/user/test_user.py
+++ b/tests/models/user/test_user.py
@@ -27,8 +27,7 @@ class TestTraktUserShow:
             "year": 2008,
             "ids": {"trakt": "1", "slug": "breaking-bad"},
             "overview": (
-                "A high school chemistry teacher diagnosed"
-                " with inoperable lung cancer."
+                "A high school chemistry teacher diagnosed with inoperable lung cancer."
             ),
         }
 

--- a/tests/server/movies/test_movies_resources.py
+++ b/tests/server/movies/test_movies_resources.py
@@ -62,8 +62,7 @@ async def test_get_popular_movies():
             "title": "Inception",
             "year": 2010,
             "overview": (
-                "A thief who steals corporate secrets"
-                " through dream-sharing technology."
+                "A thief who steals corporate secrets through dream-sharing technology."
             ),
         }
     ]

--- a/tests/server/movies/test_movies_tools.py
+++ b/tests/server/movies/test_movies_tools.py
@@ -370,10 +370,7 @@ async def test_fetch_movie_videos_with_embeds():
 
         # Verify result content
         assert "# Videos for Test Movie" in result
-        assert (
-            _IFRAME_INSTRUCTION
-            in result
-        )
+        assert _IFRAME_INSTRUCTION in result
         assert "<iframe" in result
         assert "https://www.youtube.com/embed/ABC123DEF12" in result
 
@@ -401,10 +398,7 @@ async def test_fetch_movie_videos_without_embeds():
         result = await fetch_movie_videos("test-movie", embed_markdown=False)
 
         # Should not contain iframe or instructional text
-        assert (
-            _IFRAME_INSTRUCTION
-            not in result
-        )
+        assert _IFRAME_INSTRUCTION not in result
         assert "<iframe" not in result
         assert "[▶️ Watch on YouTube]" in result
 

--- a/tests/server/search/test_search_tools.py
+++ b/tests/server/search/test_search_tools.py
@@ -265,8 +265,7 @@ async def test_search_shows_multiple_results():
                 "title": "Better Call Saul",
                 "year": 2015,
                 "overview": (
-                    "The trials and tribulations of criminal"
-                    " lawyer Jimmy McGill."
+                    "The trials and tribulations of criminal lawyer Jimmy McGill."
                 ),
                 "ids": {"trakt": "2"},
             }

--- a/tests/server/shows/test_shows_resources.py
+++ b/tests/server/shows/test_shows_resources.py
@@ -65,8 +65,7 @@ async def test_get_popular_shows():
             "title": "Breaking Bad",
             "year": 2008,
             "overview": (
-                "A high school chemistry teacher diagnosed"
-                " with inoperable lung cancer."
+                "A high school chemistry teacher diagnosed with inoperable lung cancer."
             ),
         }
     ]

--- a/tests/server/shows/test_shows_tools.py
+++ b/tests/server/shows/test_shows_tools.py
@@ -73,8 +73,7 @@ async def test_fetch_popular_shows():
             "title": "Breaking Bad",
             "year": 2008,
             "overview": (
-                "A high school chemistry teacher diagnosed"
-                " with inoperable lung cancer."
+                "A high school chemistry teacher diagnosed with inoperable lung cancer."
             ),
         }
     ]
@@ -517,10 +516,7 @@ async def test_fetch_show_videos_with_embeds():
 
         # Verify result content
         assert "# Videos for Test Show" in result
-        assert (
-            _IFRAME_INSTRUCTION
-            in result
-        )
+        assert _IFRAME_INSTRUCTION in result
         assert "<iframe" in result
         assert "https://www.youtube.com/embed/ZbsiKjVAV28" in result
 
@@ -548,10 +544,7 @@ async def test_fetch_show_videos_without_embeds():
         result = await fetch_show_videos("test-show", embed_markdown=False)
 
         # Should not contain iframe or instructional text
-        assert (
-            _IFRAME_INSTRUCTION
-            not in result
-        )
+        assert _IFRAME_INSTRUCTION not in result
         assert "<iframe" not in result
         assert "[▶️ Watch on YouTube]" in result
 

--- a/tests/utils/api/test_errors.py
+++ b/tests/utils/api/test_errors.py
@@ -568,13 +568,12 @@ class TestHandleApiErrors401RefreshAndRetry:
     @pytest.mark.asyncio
     async def test_401_refresh_raises_exception_clears_and_raises(self) -> None:
         """Test: refresh raises exception, clears token and raises original error."""
-        service = self.MockRefreshableService()
+        class BrokenRefreshService(self.MockRefreshableService):
+            async def refresh_access_token(self) -> bool:
+                self.refresh_called = True
+                raise RuntimeError("Refresh endpoint down")
 
-        async def broken_refresh() -> bool:
-            service.refresh_called = True
-            raise RuntimeError("Refresh endpoint down")
-
-        service.refresh_access_token = broken_refresh  # type: ignore[assignment]
+        service = BrokenRefreshService()
 
         with pytest.raises(AuthenticationRequiredError):
             await service.method_fails_then_succeeds()
@@ -589,7 +588,7 @@ class TestHandleApiErrors401RefreshAndRetry:
         service = self.MockRefreshableService()
 
         @handle_api_errors
-        async def method_404(self_obj: Any) -> str:
+        async def method_404(self_obj: TestHandleApiErrors401RefreshAndRetry.MockRefreshableService) -> str:
             mock_response = MagicMock()
             mock_response.status_code = 404
             mock_response.text = "Not Found"

--- a/tests/utils/api/test_errors.py
+++ b/tests/utils/api/test_errors.py
@@ -460,3 +460,188 @@ class TestDecoratorIntegration:
         assert "Authentication Required" in result
         assert "access shows" in result
         assert "start_device_auth" in result
+
+
+class TestHandleApiErrors401RefreshAndRetry:
+    """Test 401 refresh-and-retry behavior in handle_api_errors."""
+
+    @staticmethod
+    def _make_401_error() -> httpx.HTTPStatusError:
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.text = "Unauthorized"
+        return httpx.HTTPStatusError(
+            message="401 Unauthorized",
+            request=MagicMock(),
+            response=mock_response,
+        )
+
+    class MockRefreshableService:
+        """Mock service with refresh capability."""
+
+        def __init__(self) -> None:
+            self.call_count = 0
+            self.refresh_called = False
+            self.clear_auth_token_called = False
+            self.auth_token = MagicMock(refresh_token="valid_refresh_token")
+            self.refresh_result: bool = True
+
+        def clear_auth_token(self) -> bool:
+            self.clear_auth_token_called = True
+            return True
+
+        async def refresh_access_token(self) -> bool:
+            self.refresh_called = True
+            return self.refresh_result
+
+        @handle_api_errors
+        async def method_fails_then_succeeds(self) -> str:
+            """Raises 401 on first call, succeeds on second."""
+            self.call_count += 1
+            if self.call_count == 1:
+                mock_response = MagicMock()
+                mock_response.status_code = 401
+                mock_response.text = "Unauthorized"
+                raise httpx.HTTPStatusError(
+                    message="401 Unauthorized",
+                    request=MagicMock(),
+                    response=mock_response,
+                )
+            return "success"
+
+        @handle_api_errors
+        async def method_always_401(self) -> str:
+            """Always raises 401."""
+            self.call_count += 1
+            mock_response = MagicMock()
+            mock_response.status_code = 401
+            mock_response.text = "Unauthorized"
+            raise httpx.HTTPStatusError(
+                message="401 Unauthorized",
+                request=MagicMock(),
+                response=mock_response,
+            )
+
+    @pytest.mark.asyncio
+    async def test_401_refresh_succeeds_and_retry_works(self) -> None:
+        """Test: 401 triggers refresh, refresh succeeds, retry succeeds."""
+        service = self.MockRefreshableService()
+        service.refresh_result = True
+
+        result = await service.method_fails_then_succeeds()
+
+        assert result == "success"
+        assert service.call_count == 2
+        assert service.refresh_called is True
+        assert service.clear_auth_token_called is False
+
+    @pytest.mark.asyncio
+    async def test_401_refresh_fails_clears_token_and_raises(self) -> None:
+        """Test: 401 triggers refresh, refresh fails, clears token and raises."""
+        service = self.MockRefreshableService()
+        service.refresh_result = False
+
+        with pytest.raises(AuthenticationRequiredError):
+            await service.method_fails_then_succeeds()
+
+        assert service.call_count == 1
+        assert service.refresh_called is True
+        assert service.clear_auth_token_called is True
+
+    @pytest.mark.asyncio
+    async def test_401_no_refresh_token_clears_and_raises(self) -> None:
+        """Test: 401 with no refresh token available clears and raises."""
+        service = self.MockRefreshableService()
+        service.auth_token = MagicMock(refresh_token="")
+
+        with pytest.raises(AuthenticationRequiredError):
+            await service.method_fails_then_succeeds()
+
+        assert service.call_count == 1
+        assert service.refresh_called is False
+        assert service.clear_auth_token_called is True
+
+    @pytest.mark.asyncio
+    async def test_401_retry_also_401_no_infinite_loop(self) -> None:
+        """Test: refresh succeeds but retry also gets 401 — no infinite loop."""
+        service = self.MockRefreshableService()
+        service.refresh_result = True
+
+        with pytest.raises(AuthenticationRequiredError):
+            await service.method_always_401()
+
+        # Called twice: first attempt + one retry
+        assert service.call_count == 2
+        assert service.refresh_called is True
+        # Token cleared after retry failure
+        assert service.clear_auth_token_called is True
+
+    @pytest.mark.asyncio
+    async def test_401_refresh_raises_exception_clears_and_raises(self) -> None:
+        """Test: refresh raises exception, clears token and raises original error."""
+        service = self.MockRefreshableService()
+
+        async def broken_refresh() -> bool:
+            service.refresh_called = True
+            raise RuntimeError("Refresh endpoint down")
+
+        service.refresh_access_token = broken_refresh  # type: ignore[assignment]
+
+        with pytest.raises(AuthenticationRequiredError):
+            await service.method_fails_then_succeeds()
+
+        assert service.call_count == 1
+        assert service.refresh_called is True
+        assert service.clear_auth_token_called is True
+
+    @pytest.mark.asyncio
+    async def test_non_401_errors_do_not_trigger_refresh(self) -> None:
+        """Test: non-401 errors skip refresh entirely."""
+        service = self.MockRefreshableService()
+
+        @handle_api_errors
+        async def method_404(self_obj: Any) -> str:
+            mock_response = MagicMock()
+            mock_response.status_code = 404
+            mock_response.text = "Not Found"
+            raise httpx.HTTPStatusError(
+                message="404 Not Found",
+                request=MagicMock(),
+                response=mock_response,
+            )
+
+        with pytest.raises(TraktResourceNotFoundError):
+            await method_404(service)
+
+        assert service.refresh_called is False
+        assert service.clear_auth_token_called is False
+
+    @pytest.mark.asyncio
+    async def test_401_on_non_refreshable_client_clears_and_raises(self) -> None:
+        """Test: 401 on client without refresh support just clears and raises."""
+
+        class ClearOnlyService:
+            def __init__(self) -> None:
+                self.clear_auth_token_called = False
+
+            def clear_auth_token(self) -> bool:
+                self.clear_auth_token_called = True
+                return True
+
+            @handle_api_errors
+            async def method_401(self) -> str:
+                mock_response = MagicMock()
+                mock_response.status_code = 401
+                mock_response.text = "Unauthorized"
+                raise httpx.HTTPStatusError(
+                    message="401 Unauthorized",
+                    request=MagicMock(),
+                    response=mock_response,
+                )
+
+        service = ClearOnlyService()
+
+        with pytest.raises(AuthenticationRequiredError):
+            await service.method_401()
+
+        assert service.clear_auth_token_called is True

--- a/tests/utils/api/test_errors.py
+++ b/tests/utils/api/test_errors.py
@@ -465,17 +465,6 @@ class TestDecoratorIntegration:
 class TestHandleApiErrors401RefreshAndRetry:
     """Test 401 refresh-and-retry behavior in handle_api_errors."""
 
-    @staticmethod
-    def _make_401_error() -> httpx.HTTPStatusError:
-        mock_response = MagicMock()
-        mock_response.status_code = 401
-        mock_response.text = "Unauthorized"
-        return httpx.HTTPStatusError(
-            message="401 Unauthorized",
-            request=MagicMock(),
-            response=mock_response,
-        )
-
     class MockRefreshableService:
         """Mock service with refresh capability."""
 

--- a/tests/utils/api/test_errors.py
+++ b/tests/utils/api/test_errors.py
@@ -568,6 +568,7 @@ class TestHandleApiErrors401RefreshAndRetry:
     @pytest.mark.asyncio
     async def test_401_refresh_raises_exception_clears_and_raises(self) -> None:
         """Test: refresh raises exception, clears token and raises original error."""
+
         class BrokenRefreshService(self.MockRefreshableService):
             async def refresh_access_token(self) -> bool:
                 self.refresh_called = True
@@ -588,7 +589,9 @@ class TestHandleApiErrors401RefreshAndRetry:
         service = self.MockRefreshableService()
 
         @handle_api_errors
-        async def method_404(self_obj: TestHandleApiErrors401RefreshAndRetry.MockRefreshableService) -> str:
+        async def method_404(
+            self_obj: TestHandleApiErrors401RefreshAndRetry.MockRefreshableService,
+        ) -> str:
             mock_response = MagicMock()
             mock_response.status_code = 404
             mock_response.text = "Not Found"

--- a/tests/utils/api/test_responses.py
+++ b/tests/utils/api/test_responses.py
@@ -196,8 +196,7 @@ class TestHelpersIntegration:
             pytest.fail("Error response should be JSON serializable")
 
     def test_format_error_response_consistent_with_error_handling(self) -> None:
-        """Test that error response format is consistent with error handling patterns.
-        """
+        """Test error response format consistency."""
         # This test ensures the helper integrates well with the decorator error handling
         common_error_messages = [
             "Error: Unauthorized. Please check your Trakt API credentials.",

--- a/utils/api/errors.py
+++ b/utils/api/errors.py
@@ -46,6 +46,19 @@ class ClearableAuthClient(Protocol):
         ...
 
 
+@runtime_checkable
+class RefreshableAuthClient(ClearableAuthClient, Protocol):
+    """Protocol for clients that support token refresh on 401."""
+
+    async def refresh_access_token(self) -> bool:
+        """Refresh the access token using the stored refresh token.
+
+        Returns:
+            True if refresh succeeded, False if refresh failed.
+        """
+        ...
+
+
 def _auto_clear_invalid_token(client: ClearableAuthClient | object) -> None:
     """Clear invalid auth token from client if it has one.
 
@@ -114,6 +127,109 @@ class InvalidRequestError(MCPError):
         super().__init__(INVALID_REQUEST, message, data)
 
 
+def _has_refresh_token(client: object) -> bool:
+    """Check if the client has a refresh token available for recovery."""
+    auth_token = getattr(client, "auth_token", None)
+    if auth_token is None:
+        return False
+    return bool(getattr(auth_token, "refresh_token", None))
+
+
+def _is_auth_required_error(error: MCPError) -> bool:
+    """Check if an MCPError originated from a 401 HTTP status."""
+    from .error_types import AuthenticationRequiredError
+
+    return isinstance(error, AuthenticationRequiredError)
+
+
+async def _execute_method_with_error_handling(
+    method: Callable[..., Awaitable[Any]],
+    self_obj: Any,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> Any:
+    """Execute a client method with standard error handling.
+
+    Shared implementation for the first attempt and the retry after refresh.
+
+    Args:
+        method: The async method to call
+        self_obj: The client instance (self)
+        args: Positional arguments
+        kwargs: Keyword arguments
+
+    Returns:
+        Result from the method call
+
+    Raises:
+        MCPError: On API or internal errors
+    """
+    from .error_handler import TraktAPIErrorHandler
+    from .request_context import add_context_to_error_data, get_current_context
+
+    context = get_current_context()
+    correlation_id = context.correlation_id if context else None
+
+    try:
+        return await method(self_obj, *args, **kwargs)
+    except httpx.HTTPStatusError as e:
+        error = TraktAPIErrorHandler.handle_http_error(
+            error=e,
+            endpoint=context.endpoint if context else None,
+            resource_type=context.resource_type if context else None,
+            correlation_id=correlation_id,
+        )
+        if context:
+            error.data = add_context_to_error_data(error.data or {})
+        raise error from e
+    except httpx.RequestError as e:
+        error_data: dict[str, Any] = {
+            "error_type": "request_error",
+            "details": str(e),
+        }
+        if context:
+            error_data = add_context_to_error_data(error_data)
+        elif correlation_id is not None:
+            error_data["correlation_id"] = correlation_id
+
+        logger.error(f"Request error: {e!s}", extra=error_data)
+        raise InternalError(
+            "Unable to connect to Trakt API. Please check your internet connection.",
+            data=error_data,
+        ) from e
+    except MCPError:
+        raise
+    except json.JSONDecodeError as e:
+        error_data = {
+            "error_type": "json_decode_error",
+            "details": str(e),
+        }
+        if context:
+            error_data = add_context_to_error_data(error_data)
+        elif correlation_id is not None:
+            error_data["correlation_id"] = correlation_id
+
+        logger.error(f"JSON decode error: {e!s}", extra=error_data)
+        raise InternalError(
+            f"Invalid response format from API: {e!s}",
+            data=error_data,
+        ) from e
+    except (ValueError, TypeError, KeyError, AttributeError):
+        raise
+    except Exception as e:
+        error_data = {"error_type": "unexpected_error"}
+        if context:
+            error_data = add_context_to_error_data(error_data)
+        elif correlation_id is not None:
+            error_data["correlation_id"] = correlation_id
+
+        logger.exception("Unexpected error", extra=error_data)
+        raise InternalError(
+            f"An unexpected error occurred: {e!s}",
+            data=error_data,
+        ) from e
+
+
 def handle_api_errors(
     method: Callable[Concatenate[Any, ...], Awaitable[Any]],
 ) -> Callable[Concatenate[Any, ...], Awaitable[Any]]:
@@ -121,6 +237,9 @@ def handle_api_errors(
 
     This decorator is specifically designed for methods (functions with self/cls parameter).
     For standalone functions, use @handle_api_errors_func instead.
+
+    On 401 Unauthorized, attempts to refresh the access token (if the client
+    supports it) and retries the call once before clearing the token and raising.
 
     Args:
         method: The async method to wrap
@@ -131,101 +250,46 @@ def handle_api_errors(
 
     @functools.wraps(method)
     async def wrapper(self: Any, /, *args: Any, **kwargs: Any) -> Any:
-        # Import here to avoid circular imports
-        from .error_handler import TraktAPIErrorHandler
-        from .request_context import add_context_to_error_data, get_current_context
-
-        # Get current request context
-        context = get_current_context()
-        correlation_id = context.correlation_id if context else None
-
         try:
-            result = await method(self, *args, **kwargs)
-            return result
-        except httpx.HTTPStatusError as e:
-            # Use centralized error handler with enhanced context
-            error = TraktAPIErrorHandler.handle_http_error(
-                error=e,
-                endpoint=context.endpoint if context else None,
-                resource_type=context.resource_type if context else None,
-                correlation_id=correlation_id,
-            )
-            # Add full request context to error data
-            if context:
-                error.data = add_context_to_error_data(error.data or {})
+            # First attempt — do NOT clear token on 401 so refresh can recover
+            return await _execute_method_with_error_handling(method, self, args, kwargs)
+        except MCPError as first_error:
+            if not _is_auth_required_error(first_error):
+                raise
 
-            # Auto-clear invalid tokens on 401 Unauthorized
-            if e.response.status_code == 401:
-                _auto_clear_invalid_token(self)
+            # 401 path — attempt refresh if client supports it.
+            # Guard against recursive refresh: if _refresh_lock is held,
+            # we're already inside refresh_access_token's HTTP call chain.
+            refresh_lock = getattr(self, "_refresh_lock", None)
+            already_refreshing = refresh_lock is not None and refresh_lock.locked()
 
-            raise error from e
-        except httpx.RequestError as e:
-            # Create base error data with context
-            error_data = {
-                "error_type": "request_error",
-                "details": str(e),
-            }
-            if context:
-                error_data = add_context_to_error_data(error_data)
-            else:
-                if correlation_id is not None:
-                    error_data["correlation_id"] = correlation_id
+            if (
+                not already_refreshing
+                and isinstance(self, RefreshableAuthClient)
+                and _has_refresh_token(self)
+            ):
+                try:
+                    refreshed = await self.refresh_access_token()
+                except Exception:
+                    logger.warning(
+                        "Token refresh failed during 401 recovery", exc_info=True
+                    )
+                    refreshed = False
 
-            logger.error(
-                f"Request error: {e!s}",
-                extra=error_data,
-            )
-            raise InternalError(
-                "Unable to connect to Trakt API. Please check your internet connection.",
-                data=error_data,
-            ) from e
-        except MCPError:
-            # Re-raise MCP errors as-is — client methods should propagate auth
-            # errors to the server layer, where with_error_handling or
-            # handle_api_errors_func converts them to friendly messages.
+                if refreshed:
+                    try:
+                        # Retry once with refreshed token
+                        return await _execute_method_with_error_handling(
+                            method, self, args, kwargs
+                        )
+                    except MCPError:
+                        # Retry also failed — clear and raise the retry error
+                        _auto_clear_invalid_token(self)
+                        raise
+
+            # No refresh possible or refresh failed — clear and raise original
+            _auto_clear_invalid_token(self)
             raise
-        except json.JSONDecodeError as e:
-            # Treat JSON decode errors as internal errors
-            error_data = {
-                "error_type": "json_decode_error",
-                "details": str(e),
-            }
-            if context:
-                error_data = add_context_to_error_data(error_data)
-            else:
-                if correlation_id is not None:
-                    error_data["correlation_id"] = correlation_id
-
-            logger.error(
-                f"JSON decode error: {e!s}",
-                extra=error_data,
-            )
-            raise InternalError(
-                f"Invalid response format from API: {e!s}",
-                data=error_data,
-            ) from e
-        except (ValueError, TypeError, KeyError, AttributeError):
-            # Re-raise business logic errors as-is
-            raise
-        except Exception as e:
-            # Create base error data with context
-            error_data = {
-                "error_type": "unexpected_error",
-            }
-            if context:
-                error_data = add_context_to_error_data(error_data)
-            else:
-                if correlation_id is not None:
-                    error_data["correlation_id"] = correlation_id
-
-            logger.exception(
-                "Unexpected error",
-                extra=error_data,
-            )
-            raise InternalError(
-                f"An unexpected error occurred: {e!s}",
-                data=error_data,
-            ) from e
 
     return wrapper
 
@@ -361,6 +425,7 @@ __all__ = [
     "InvalidParamsError",
     "InvalidRequestError",
     "MCPError",
+    "RefreshableAuthClient",
     "handle_api_errors",
     "handle_api_errors_func",
 ]


### PR DESCRIPTION
Tests were writing mock token data (access_token_123) to the real auth_token.json because test_auth_flow.py patched builtins.open but _save_auth_token uses os.open/os.fdopen/os.replace. After running tests and restarting the MCP server, all authenticated API calls failed with 401 while check_auth_status falsely reported success.

- Add autouse session fixture to redirect AUTH_TOKEN_FILE to a temp path, preventing any test from touching the real token file
- Fix test_auth_flow.py to mock the actual I/O calls (os.open etc.)
- Update hardcoded "auth_token.json" assertions to use dynamic path
- Add 401 refresh-and-retry to handle_api_errors: on 401, attempt token refresh before clearing; retry the call once if refresh succeeds; includes _refresh_lock guard to prevent recursive refresh
- Add RefreshableAuthClient protocol for type-safe refresh detection
- Add 7 tests covering refresh success/failure/no-token/no-loop cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication handling: on a 401 the system will attempt a token refresh (if the client supports it and a refresh token exists) and retry once; if refresh fails or is unavailable the token is cleared and an auth error is raised.
  * Non-401 errors no longer trigger token refresh or token clearing.

* **Tests**
  * Expanded coverage for auth error and retry scenarios and isolated token file persistence during the test session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->