### PR TITLE
fix: enforce E501 line-length lint rule and fix all 259 violations

### DIFF
--- a/client/auth/client.py
+++ b/client/auth/client.py
@@ -200,7 +200,8 @@ class AuthClient(BaseClient):
                 # OSError (file I/O), ValueError (validation).
                 # Keep the refresh token so the next attempt can succeed.
                 logger.warning(
-                    "Failed to refresh access token (transient error), keeping refresh token for next attempt",
+                    "Failed to refresh access token (transient"
+                    + " error), keeping refresh token for next attempt",
                     exc_info=True,
                 )
                 return False
@@ -237,7 +238,8 @@ class AuthClient(BaseClient):
             if self.auth_token is None:
                 return False
 
-            # Always clear in-memory state first (handles case where file was deleted externally)
+            # Always clear in-memory state first
+            # (handles case where file was deleted externally)
             self.auth_token = None
             if "Authorization" in self.headers:
                 del self.headers["Authorization"]

--- a/client/base.py
+++ b/client/base.py
@@ -32,7 +32,10 @@ def _is_dict_response(result: Any) -> TypeGuard[dict[str, Any]]:
 
 def _is_list_response(result: Any) -> TypeGuard[list[dict[str, Any]]]:
     """Type guard for list responses."""
-    return isinstance(result, list) and all(isinstance(item, dict) for item in result)  # type: ignore[reportUnknownVariableType] # Runtime type guard validation
+    return isinstance(result, list) and all(
+        isinstance(item, dict)
+        for item in result  # type: ignore[reportUnknownVariableType]
+    )
 
 
 def _is_pydantic_model(cls: type[object]) -> TypeGuard[type[PydanticModel]]:
@@ -189,9 +192,11 @@ class BaseClient:
         result = await self._make_request("GET", endpoint, params=params)
         if _is_list_response(result):
             return result
-        raise ValueError(
-            f"Expected list response from {endpoint}, got {type(result).__name__}: {result}"
+        msg = (
+            f"Expected list response from {endpoint}, "
+            + f"got {type(result).__name__}: {result}"
         )
+        raise ValueError(msg)
 
     async def _make_dict_request(
         self, endpoint: str, params: dict[str, Any] | None = None
@@ -200,9 +205,11 @@ class BaseClient:
         result = await self._make_request("GET", endpoint, params=params)
         if _is_dict_response(result):
             return result
-        raise ValueError(
-            f"Expected dict response from {endpoint}, got {type(result).__name__}: {result}"
+        msg = (
+            f"Expected dict response from {endpoint}, "
+            + f"got {type(result).__name__}: {result}"
         )
+        raise ValueError(msg)
 
     async def _post_request(
         self,
@@ -214,9 +221,11 @@ class BaseClient:
         result = await self._make_request("POST", endpoint, data=data, headers=headers)
         if _is_dict_response(result):
             return result
-        raise ValueError(
-            f"Expected dict response from POST {endpoint}, got {type(result).__name__}: {result}"
+        msg = (
+            f"Expected dict response from POST {endpoint}, "
+            + f"got {type(result).__name__}: {result}"
         )
+        raise ValueError(msg)
 
     @handle_api_errors
     async def _delete_request(self, endpoint: str) -> None:
@@ -278,18 +287,23 @@ class BaseClient:
         if response_type is None:
             if _is_dict_response(result):
                 return result
-            raise ValueError(
-                f"Expected dict response from {endpoint}, got {type(result).__name__}: {result}"
+            msg = (
+                f"Expected dict response from {endpoint}, "
+                + f"got {type(result).__name__}: {result}"
             )
+            raise ValueError(msg)
 
         if _is_pydantic_model(response_type):
             return response_type.model_validate(result)
 
         if not _is_dict_response(result):
-            raise ValueError(
-                f"Expected dict-like response for {response_type.__name__} from {endpoint}, "
-                + f"got {type(result).__name__}: {result}"
+            msg = (
+                "Expected dict-like response for"
+                + f" {response_type.__name__}"
+                + f" from {endpoint},"
+                + f" got {type(result).__name__}: {result}"
             )
+            raise ValueError(msg)
 
         return result  # type: ignore[return-value] # TypedDict runtime limitation
 
@@ -363,10 +377,11 @@ class BaseClient:
             try:
                 pagination = self._extract_pagination_headers(response)
             except ValueError as e:
-                # Convert to an exception type that will be handled by @handle_api_errors
+                # Convert to an exception type handled by @handle_api_errors
                 raise RuntimeError(f"Failed to parse pagination headers: {e}") from e
 
-            # Fix total_items when no pagination headers present (non-paginated requests)
+            # Fix total_items when no pagination headers present
+            # (non-paginated requests)
             if pagination.total_items == 0 and len(typed_data) > 0:
                 pagination = PaginationMetadata(
                     current_page=pagination.current_page,

--- a/client/episodes/lists.py
+++ b/client/episodes/lists.py
@@ -45,7 +45,8 @@ class EpisodeListsClient(BaseClient):
             season: Season number (0 for specials)
             episode: Episode number
             list_type: Filter by type: 'all', 'personal', 'official', 'watchlists'
-            sort: Sort order: 'popular', 'likes', 'comments', 'items', 'added', 'updated'
+            sort: Sort order: 'popular', 'likes', 'comments', 'items', 'added',
+                'updated'
 
         Returns:
             List of list data
@@ -54,7 +55,10 @@ class EpisodeListsClient(BaseClient):
             ValueError: If list_type or sort is not a valid value
         """
         if list_type not in VALID_LIST_TYPES:
-            msg = f"list_type must be one of {sorted(VALID_LIST_TYPES)}, got: '{list_type}'"
+            msg = (
+                f"list_type must be one of {sorted(VALID_LIST_TYPES)},"
+                f" got: '{list_type}'"
+            )
             raise ValueError(msg)
         if sort not in VALID_SORT_VALUES:
             msg = f"sort must be one of {sorted(VALID_SORT_VALUES)}, got: '{sort}'"

--- a/client/movies/client.py
+++ b/client/movies/client.py
@@ -29,7 +29,8 @@ class MoviesClient(
     - PopularMoviesClient: get_popular_movies()
     - AnticipatedMoviesClient: get_anticipated_movies()
     - BoxOfficeMoviesClient: get_boxoffice_movies()
-    - MovieStatsClient: get_favorited_movies(), get_played_movies(), get_watched_movies()
+    - MovieStatsClient: get_favorited_movies(), get_played_movies(),
+      get_watched_movies()
     - MovieDetailsClient: get_movie(), get_movie_ratings()
     - MovieVideosClient: get_videos()
     - RelatedMoviesClient: get_related_movies()

--- a/client/movies/details.py
+++ b/client/movies/details.py
@@ -33,7 +33,8 @@ class MovieDetailsClient(BaseClient):
             movie_id: The Trakt movie ID
 
         Returns:
-            Extended movie details data including status, enhanced overview, and metadata
+            Extended movie details data including status, enhanced overview,
+            and metadata
         """
         endpoint = f"/movies/{quote(movie_id, safe='')}"
         params = {"extended": "full"}

--- a/client/people/utils.py
+++ b/client/people/utils.py
@@ -34,7 +34,10 @@ def validate_person_id(person_id: str) -> str:
         raise ValueError(msg)
 
     if person_id.startswith("tt") and not _IMDB_PATTERN.match(person_id):
-        msg = f"Invalid IMDB ID format: '{person_id}'. Expected format: tt followed by digits (e.g. tt0186151)"
+        msg = (
+            f"Invalid IMDB ID format: '{person_id}'."
+            " Expected format: tt followed by digits (e.g. tt0186151)"
+        )
         raise ValueError(msg)
 
     return person_id

--- a/client/recommendations/client.py
+++ b/client/recommendations/client.py
@@ -8,11 +8,14 @@ class RecommendationsClient(MovieRecommendationsClient, ShowRecommendationsClien
     """Unified client for all recommendation operations.
 
     Combines functionality from:
-    - MovieRecommendationsClient: get_movie_recommendations(), hide_movie_recommendation()
-    - ShowRecommendationsClient: get_show_recommendations(), hide_show_recommendation()
+    - MovieRecommendationsClient: get_movie_recommendations(),
+      hide_movie_recommendation()
+    - ShowRecommendationsClient: get_show_recommendations(),
+      hide_show_recommendation()
 
-    Note: Inherits OAuth authentication handling from AuthClient through parent clients.
-    All recommendation operations require user authentication to access personalized data.
+    Note: Inherits OAuth authentication handling from AuthClient through parent
+    clients. All recommendation operations require user authentication to access
+    personalized data.
     """
 
     pass

--- a/client/seasons/lists.py
+++ b/client/seasons/lists.py
@@ -28,7 +28,8 @@ class SeasonListsClient(BaseClient):
             show_id: Trakt ID, slug, or IMDB ID
             season: Season number (0 for specials)
             list_type: Filter by type: 'all', 'personal', 'official', 'watchlists'
-            sort: Sort order: 'popular', 'likes', 'comments', 'items', 'added', 'updated'
+            sort: Sort order: 'popular', 'likes', 'comments', 'items', 'added',
+                'updated'
 
         Returns:
             List of list data

--- a/client/sync/client.py
+++ b/client/sync/client.py
@@ -10,7 +10,8 @@ class SyncClient(SyncRatingsClient, SyncWatchlistClient, SyncHistoryClient):
 
     Combines functionality from:
     - SyncRatingsClient: get_sync_ratings(), add_sync_ratings(), remove_sync_ratings()
-    - SyncWatchlistClient: get_sync_watchlist(), add_sync_watchlist(), remove_sync_watchlist()
+    - SyncWatchlistClient: get_sync_watchlist(), add_sync_watchlist(),
+      remove_sync_watchlist()
     - SyncHistoryClient: get_history(), add_to_history(), remove_from_history()
 
     Note: Inherits OAuth authentication handling from AuthClient through parent clients.

--- a/client/sync/ratings_client.py
+++ b/client/sync/ratings_client.py
@@ -98,7 +98,8 @@ class SyncRatingsClient(AuthClient):
         """Remove ratings for the authenticated user.
 
         Args:
-            request: Rating items to remove (should not include rating values, just item identification)
+            request: Rating items to remove (should not include rating values,
+                just item identification)
 
         Returns:
             Summary of removed ratings with counts and any not found items

--- a/client/sync/watchlist_client.py
+++ b/client/sync/watchlist_client.py
@@ -45,8 +45,10 @@ class SyncWatchlistClient(AuthClient):
         """Get user's watchlist from sync API with pagination.
 
         Args:
-            watchlist_type: Type of watchlist items to get (all, movies, shows, seasons, episodes)
-            sort_by: Field to sort by (rank, added, title, released, runtime, popularity, etc.)
+            watchlist_type: Type of watchlist items to get
+                (all, movies, shows, seasons, episodes)
+            sort_by: Field to sort by (rank, added, title, released, runtime,
+                popularity, etc.)
             sort_how: Sort direction (asc or desc)
             pagination: Optional pagination parameters (page, limit)
 
@@ -121,7 +123,8 @@ class SyncWatchlistClient(AuthClient):
         """Remove items from the authenticated user's watchlist.
 
         Args:
-            request: Watchlist items to remove (should not include notes, just item identification)
+            request: Watchlist items to remove (should not include notes,
+                just item identification)
 
         Returns:
             Summary of removed items with counts and any not found items

--- a/client/validation.py
+++ b/client/validation.py
@@ -32,7 +32,10 @@ def validate_media_id(media_id: str, field_name: str = "id") -> str:
         raise ValueError(msg)
 
     if media_id.startswith("tt") and not _IMDB_PATTERN.match(media_id):
-        msg = f"Invalid IMDB ID format for {field_name}: '{media_id}'. Expected format: tt followed by digits (e.g. tt1104001)"
+        msg = (
+            f"Invalid IMDB ID format for {field_name}: '{media_id}'."
+            " Expected format: tt followed by digits (e.g. tt1104001)"
+        )
         raise ValueError(msg)
 
     return media_id

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -3,7 +3,8 @@
 This module provides access to domain-focused configuration components:
 
 - config.api: API-related constants (DEFAULT_LIMIT)
-- config.auth: Authentication constants (AUTH_EXPIRATION, AUTH_POLL_INTERVAL, AUTH_VERIFICATION_URL)
+- config.auth: Authentication constants (AUTH_EXPIRATION, AUTH_POLL_INTERVAL,
+  AUTH_VERIFICATION_URL)
 - config.endpoints: Trakt API endpoints (TRAKT_ENDPOINTS)
 - config.mcp: MCP server configuration (MCP_RESOURCES, TOOL_NAMES)
 

--- a/config/endpoints/episodes.py
+++ b/config/endpoints/episodes.py
@@ -4,7 +4,9 @@ from typing import Final
 
 EPISODES_ENDPOINTS: Final[dict[str, str]] = {
     "episode_summary": "/shows/:id/seasons/:season/episodes/:episode",
-    "episode_translations": "/shows/:id/seasons/:season/episodes/:episode/translations/:language",
+    "episode_translations": (
+        "/shows/:id/seasons/:season/episodes/:episode/translations/:language"
+    ),
     "episode_lists": "/shows/:id/seasons/:season/episodes/:episode/lists/:type/:sort",
     "episode_people": "/shows/:id/seasons/:season/episodes/:episode/people",
     "episode_ratings": "/shows/:id/seasons/:season/episodes/:episode/ratings",

--- a/models/formatters/__init__.py
+++ b/models/formatters/__init__.py
@@ -6,7 +6,8 @@ This module provides domain-focused formatters for different types of Trakt data
 - models.formatters.checkin: Check-in formatting (CheckinFormatters)
 - models.formatters.comments: Comments formatting (CommentsFormatters)
 - models.formatters.movies: Movies formatting (MovieFormatters)
-- models.formatters.recommendations: Recommendations formatting (RecommendationFormatters)
+- models.formatters.recommendations: Recommendations formatting
+  (RecommendationFormatters)
 - models.formatters.search: Search formatting (SearchFormatters)
 - models.formatters.shows: Shows formatting (ShowFormatters)
 - models.formatters.sync_ratings: Sync ratings formatting (SyncRatingsFormatters)

--- a/models/formatters/progress.py
+++ b/models/formatters/progress.py
@@ -162,7 +162,8 @@ class ProgressFormatters:
                 "Items appear here when you pause a movie or episode during playback."
             )
 
-        result = f"# Playback Progress ({len(items)} item{'s' if len(items) != 1 else ''})\n\n"
+        plural = "s" if len(items) != 1 else ""
+        result = f"# Playback Progress ({len(items)} item{plural})\n\n"
 
         # Group by type
         movies = [i for i in items if i.type == "movie"]

--- a/models/formatters/recommendations.py
+++ b/models/formatters/recommendations.py
@@ -63,7 +63,10 @@ class RecommendationFormatters:
         result += "_Personalized recommendations based on your viewing history_\n\n"
 
         if not movies:
-            return f"{result}No recommendations available. Watch more content to improve recommendations!\n"
+            return (
+                f"{result}No recommendations available."
+                " Watch more content to improve recommendations!\n"
+            )
 
         for movie in movies:
             result += RecommendationFormatters._format_recommendation_item(movie)
@@ -86,7 +89,10 @@ class RecommendationFormatters:
         result += "_Personalized recommendations based on your viewing history_\n\n"
 
         if not shows:
-            return f"{result}No recommendations available. Watch more content to improve recommendations!\n"
+            return (
+                f"{result}No recommendations available."
+                " Watch more content to improve recommendations!\n"
+            )
 
         for show in shows:
             result += RecommendationFormatters._format_recommendation_item(show)

--- a/models/types/protocols.py
+++ b/models/types/protocols.py
@@ -62,11 +62,14 @@ class ShowsClientProtocol(Protocol):
 
         Args:
             limit: Items per page
-            page: Page number (optional). If None, returns all results via auto-pagination.
-            max_pages: Maximum number of pages to fetch when auto-paginating (default: 100)
+            page: Page number (optional). If None, returns all results
+                via auto-pagination.
+            max_pages: Maximum number of pages to fetch when
+                auto-paginating (default: 100)
 
         Returns:
-            If page is None: List of all trending shows across all pages (up to max_pages)
+            If page is None: List of all trending shows across all pages
+                (up to max_pages)
             If page specified: Paginated response with metadata for that page
         """
         ...
@@ -81,11 +84,14 @@ class ShowsClientProtocol(Protocol):
 
         Args:
             limit: Items per page
-            page: Page number (optional). If None, returns all results via auto-pagination.
-            max_pages: Maximum number of pages to fetch when auto-paginating (default: 100)
+            page: Page number (optional). If None, returns all results
+                via auto-pagination.
+            max_pages: Maximum number of pages to fetch when
+                auto-paginating (default: 100)
 
         Returns:
-            If page is None: List of all popular shows across all pages (up to max_pages)
+            If page is None: List of all popular shows across all pages
+                (up to max_pages)
             If page specified: Paginated response with metadata for that page
         """
         ...
@@ -100,11 +106,14 @@ class ShowsClientProtocol(Protocol):
 
         Args:
             limit: Items per page
-            page: Page number (optional). If None, returns all results via auto-pagination.
-            max_pages: Maximum number of pages to fetch when auto-paginating (default: 100)
+            page: Page number (optional). If None, returns all results
+                via auto-pagination.
+            max_pages: Maximum number of pages to fetch when
+                auto-paginating (default: 100)
 
         Returns:
-            If page is None: List of all anticipated shows across all pages (up to max_pages)
+            If page is None: List of all anticipated shows across all pages
+                (up to max_pages)
             If page specified: Paginated response with metadata for that page
         """
         ...
@@ -145,11 +154,14 @@ class MoviesClientProtocol(Protocol):
 
         Args:
             limit: Items per page
-            page: Page number (optional). If None, returns all results via auto-pagination.
-            max_pages: Maximum number of pages to fetch when auto-paginating (default: 100)
+            page: Page number (optional). If None, returns all results
+                via auto-pagination.
+            max_pages: Maximum number of pages to fetch when
+                auto-paginating (default: 100)
 
         Returns:
-            If page is None: List of all trending movies across all pages (up to max_pages)
+            If page is None: List of all trending movies across all pages
+                (up to max_pages)
             If page specified: Paginated response with metadata for that page
         """
         ...
@@ -164,11 +176,14 @@ class MoviesClientProtocol(Protocol):
 
         Args:
             limit: Items per page
-            page: Page number (optional). If None, returns all results via auto-pagination.
-            max_pages: Maximum number of pages to fetch when auto-paginating (default: 100)
+            page: Page number (optional). If None, returns all results
+                via auto-pagination.
+            max_pages: Maximum number of pages to fetch when
+                auto-paginating (default: 100)
 
         Returns:
-            If page is None: List of all popular movies across all pages (up to max_pages)
+            If page is None: List of all popular movies across all pages
+                (up to max_pages)
             If page specified: Paginated response with metadata for that page
         """
         ...
@@ -183,11 +198,14 @@ class MoviesClientProtocol(Protocol):
 
         Args:
             limit: Items per page
-            page: Page number (optional). If None, returns all results via auto-pagination.
-            max_pages: Maximum number of pages to fetch when auto-paginating (default: 100)
+            page: Page number (optional). If None, returns all results
+                via auto-pagination.
+            max_pages: Maximum number of pages to fetch when
+                auto-paginating (default: 100)
 
         Returns:
-            If page is None: List of all anticipated movies across all pages (up to max_pages)
+            If page is None: List of all anticipated movies across all pages
+                (up to max_pages)
             If page specified: Paginated response with metadata for that page
         """
         ...
@@ -304,11 +322,14 @@ class SearchClientProtocol(Protocol):
         Args:
             query: Search query string
             limit: Items per page
-            page: Page number (optional). If None, returns all results via auto-pagination.
-            max_pages: Maximum number of pages to fetch when auto-paginating (default: 100)
+            page: Page number (optional). If None, returns all results
+                via auto-pagination.
+            max_pages: Maximum number of pages to fetch when
+                auto-paginating (default: 100)
 
         Returns:
-            If page is None: List of all search results across all pages (up to max_pages)
+            If page is None: List of all search results across all pages
+                (up to max_pages)
             If page specified: Paginated response with metadata for that page
         """
         ...
@@ -325,11 +346,14 @@ class SearchClientProtocol(Protocol):
         Args:
             query: Search query string
             limit: Items per page
-            page: Page number (optional). If None, returns all results via auto-pagination.
-            max_pages: Maximum number of pages to fetch when auto-paginating (default: 100)
+            page: Page number (optional). If None, returns all results
+                via auto-pagination.
+            max_pages: Maximum number of pages to fetch when
+                auto-paginating (default: 100)
 
         Returns:
-            If page is None: List of all search results across all pages (up to max_pages)
+            If page is None: List of all search results across all pages
+                (up to max_pages)
             If page specified: Paginated response with metadata for that page
         """
         ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ select = [
     "PERF", # Performance
 ]
 ignore = [
-    "E501", # line too long (handled by formatter)
     "UP040", # Type alias uses TypeAlias annotation (Python 3.12+ feature)
 ]
 

--- a/server/auth/tools.py
+++ b/server/auth/tools.py
@@ -86,7 +86,10 @@ async def start_device_auth() -> str:
 
     return f"""{instructions}
 
-I won't automatically check your authentication status until you tell me you've completed the authorization. Once you've finished the authorization process on the Trakt website, simply tell me "I've completed the authorization" and I'll verify it for you."""
+I won't automatically check your authentication status until you tell me you've
+completed the authorization. Once you've finished the authorization process on
+the Trakt website, simply tell me "I've completed the authorization" and I'll
+verify it for you."""
 
 
 async def check_auth_status() -> str:
@@ -101,7 +104,8 @@ async def check_auth_status() -> str:
     if client.is_authenticated():
         return """# Authentication Successful!
 
-You are now authenticated with Trakt. You can access your personal data using tools like `fetch_user_watched_shows` and `fetch_user_watched_movies`.
+You are now authenticated with Trakt. You can access your personal data using
+tools like `fetch_user_watched_shows` and `fetch_user_watched_movies`.
 
 If you want to log out at any point, you can use the `clear_auth` tool."""
 
@@ -110,13 +114,19 @@ If you want to log out at any point, you can use the `clear_auth` tool."""
 
     async with auth_flow_lock:
         if not active_auth_flow or "device_code" not in active_auth_flow:
-            return "No active authentication flow. Use the `start_device_auth` tool to begin authentication."
+            return (
+                "No active authentication flow. "
+                "Use the `start_device_auth` tool to begin authentication."
+            )
 
         # Check if flow is expired
         current_time = int(time.time())
         if current_time > active_auth_flow["expires_at"]:
             active_auth_flow = {}
-            return "Authentication flow expired. Please start a new one with the `start_device_auth` tool."
+            return (
+                "Authentication flow expired. "
+                "Please start a new one with the `start_device_auth` tool."
+            )
 
         # Check if it's too early to poll again
         if current_time - active_auth_flow["last_poll"] < active_auth_flow["interval"]:
@@ -142,13 +152,16 @@ I don't see that you've completed the authorization yet. Please make sure to:
 2. Enter your code
 3. Approve the authorization request
 
-If you've already done this and are still seeing this message, please wait a few seconds and try again by telling me "Please check my authorization status"."""
+If you've already done this and are still seeing this message, please wait a
+few seconds and try again by telling me "Please check my authorization status"."""
     except InternalError as e:
         # Handle server errors gracefully to avoid breaking the polling loop
         logger.warning(f"Internal error during auth token retrieval: {e}")
         return """# Authorization Check Failed
 
-Unable to check authorization status due to a server error. This sometimes happens during the authorization process. Please wait a moment and try again by telling me "Please check my authorization status".
+Unable to check authorization status due to a server error. This sometimes
+happens during the authorization process. Please wait a moment and try again
+by telling me "Please check my authorization status".
 
 If this error persists, you may need to restart the authentication process."""
     else:
@@ -157,7 +170,9 @@ If this error persists, you may need to restart the authentication process."""
             active_auth_flow = {}
         return """# Authentication Successful!
 
-You have successfully authorized the Trakt MCP application. You can now access your personal Trakt data using tools like `fetch_user_watched_shows` and `fetch_user_watched_movies`.
+You have successfully authorized the Trakt MCP application. You can now access
+your personal Trakt data using tools like `fetch_user_watched_shows` and
+`fetch_user_watched_movies`.
 
 If you want to log out at any point, you can use the `clear_auth` tool."""
 
@@ -177,7 +192,10 @@ async def clear_auth() -> str:
 
     # Try to clear the token
     if client.clear_auth_token():
-        return "You have been successfully logged out of Trakt. Your authentication token has been cleared."
+        return (
+            "You have been successfully logged out of Trakt. "
+            "Your authentication token has been cleared."
+        )
     else:
         return "You were not authenticated with Trakt."
 

--- a/server/base/error_mixin.py
+++ b/server/base/error_mixin.py
@@ -367,7 +367,8 @@ class BaseToolErrorMixin:
         """Validate that at least one set of alternative parameters is provided.
 
         Args:
-            param_sets: List of parameter sets, where each set is a tuple of parameter names
+            param_sets: List of parameter sets, where each set is a tuple of
+                parameter names
             **params: Parameter name -> value pairs to validate
 
         Raises:

--- a/server/base/identifier_mixin.py
+++ b/server/base/identifier_mixin.py
@@ -118,9 +118,11 @@ class IdentifierValidatorMixin(BaseModel):
     def _validate_imdb_id_format(cls, v: str | None) -> str | None:
         """Ensure imdb_id follows tt + digits format if provided."""
         if v is not None and not re.match(r"^tt\d+$", v):
-            raise ValueError(
-                f"imdb_id must be in format 'tt' followed by digits (e.g., 'tt0468569'), got: '{v}'"
+            msg = (
+                "imdb_id must be in format 'tt' followed"
+                + f" by digits (e.g., 'tt0468569'), got: '{v}'"
             )
+            raise ValueError(msg)
         return v
 
     @model_validator(mode="after")
@@ -133,10 +135,13 @@ class IdentifierValidatorMixin(BaseModel):
 
         if not has_id and not has_title_year:
             prefix = self._identifier_error_prefix
-            raise ValueError(
-                f"{prefix} must include either an identifier (trakt_id, slug, imdb_id, tmdb_id, or tvdb_id) "
-                + "or both title and year for proper identification"
+            msg = (
+                f"{prefix} must include either an identifier"
+                + " (trakt_id, slug, imdb_id, tmdb_id, or"
+                + " tvdb_id) or both title and year for"
+                + " proper identification"
             )
+            raise ValueError(msg)
         return self
 
     def build_ids_dict(self) -> dict[str, str | int]:

--- a/server/checkin/tools.py
+++ b/server/checkin/tools.py
@@ -32,13 +32,15 @@ async def checkin_to_show(
 ) -> str:
     """Check in to a show episode that the user is currently watching.
 
-    This will mark the episode as watched on Trakt and can optionally share to connected social media.
-    First use the search_shows tool to find the correct show_id before checking in, or provide the show title.
+    This will mark the episode as watched on Trakt and can optionally share to
+    connected social media. First use the search_shows tool to find the correct
+    show_id before checking in, or provide the show title.
 
     Args:
         season: Season number
         episode: Episode number
-        show_id: Trakt ID for the show (use search_shows to find this, optional if show_title is provided)
+        show_id: Trakt ID for the show (use search_shows to find this,
+            optional if show_title is provided)
         show_title: Title of the show (optional if show_id is provided)
         show_year: Year the show was released (optional, can help with ambiguous titles)
         message: Optional message to include with the checkin
@@ -119,43 +121,63 @@ def register_checkin_tools(mcp: FastMCP) -> Any:
         show_id: Annotated[
             str | None,
             Field(
-                description=f"{SHOW_ID_DESCRIPTION}. Provide either show_id OR show_title."
+                description=(
+                    f"{SHOW_ID_DESCRIPTION}. Provide either show_id OR show_title."
+                )
             ),
         ] = None,
         show_title: Annotated[
             str | None,
             Field(
-                description="Title of the show (e.g., 'Breaking Bad'). Provide either show_title OR show_id."
+                description=(
+                    "Title of the show (e.g., 'Breaking Bad'). "
+                    "Provide either show_title OR show_id."
+                )
             ),
         ] = None,
         show_year: Annotated[
             int | None,
             Field(
-                description="Year the show first aired (e.g., 2008). Helps disambiguate shows with the same title."
+                description=(
+                    "Year the show first aired (e.g., 2008). "
+                    "Helps disambiguate shows with the same title."
+                )
             ),
         ] = None,
         message: Annotated[
             str,
             Field(
-                description="Optional message to share on connected social networks. If not provided, uses the user's default watching message."
+                description=(
+                    "Optional message to share on connected social networks. "
+                    "If not provided, uses the user's default watching message."
+                )
             ),
         ] = "",
         share_twitter: Annotated[
             bool,
             Field(
-                description="Share this check-in on Twitter. Overrides user's default sharing setting."
+                description=(
+                    "Share this check-in on Twitter. "
+                    "Overrides user's default sharing setting."
+                )
             ),
         ] = False,
         share_mastodon: Annotated[
             bool,
             Field(
-                description="Share this check-in on Mastodon. Overrides user's default sharing setting."
+                description=(
+                    "Share this check-in on Mastodon. "
+                    "Overrides user's default sharing setting."
+                )
             ),
         ] = False,
         share_tumblr: Annotated[
             bool,
             Field(
-                description="Share this check-in on Tumblr. Overrides user's default sharing setting."
+                description=(
+                    "Share this check-in on Tumblr. "
+                    "Overrides user's default sharing setting."
+                )
             ),
         ] = False,
     ) -> str:

--- a/server/comments/tools.py
+++ b/server/comments/tools.py
@@ -602,7 +602,11 @@ def register_comment_tools(
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_movie_comments"],
-        description="Fetch comments for a specific movie from Trakt. Supports optional pagination with 'page' parameter and safety cap 'max_pages'.",
+        description=(
+            "Fetch comments for a specific movie from Trakt. "
+            "Supports optional pagination with 'page' parameter and "
+            "safety cap 'max_pages'."
+        ),
     )
     async def fetch_movie_comments_tool(
         movie_id: Annotated[str, Field(min_length=1, description=MOVIE_ID_DESCRIPTION)],
@@ -626,7 +630,11 @@ def register_comment_tools(
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_show_comments"],
-        description="Fetch comments for a specific TV show from Trakt. Supports optional pagination with 'page' parameter and safety cap 'max_pages'.",
+        description=(
+            "Fetch comments for a specific TV show from Trakt. "
+            "Supports optional pagination with 'page' parameter and "
+            "safety cap 'max_pages'."
+        ),
     )
     async def fetch_show_comments_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -650,7 +658,11 @@ def register_comment_tools(
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_season_comments"],
-        description="Fetch comments for a specific TV show season from Trakt. Supports optional pagination with 'page' parameter and safety cap 'max_pages'.",
+        description=(
+            "Fetch comments for a specific TV show season from Trakt. "
+            "Supports optional pagination with 'page' parameter and "
+            "safety cap 'max_pages'."
+        ),
     )
     async def fetch_season_comments_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -675,7 +687,11 @@ def register_comment_tools(
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_episode_comments"],
-        description="Fetch comments for a specific TV show episode from Trakt. Supports optional pagination with 'page' parameter and safety cap 'max_pages'.",
+        description=(
+            "Fetch comments for a specific TV show episode from Trakt. "
+            "Supports optional pagination with 'page' parameter and "
+            "safety cap 'max_pages'."
+        ),
     )
     async def fetch_episode_comments_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -715,7 +731,11 @@ def register_comment_tools(
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_comment_replies"],
-        description="Fetch replies for a specific comment from Trakt. Supports optional pagination with 'page' parameter and safety cap 'max_pages'.",
+        description=(
+            "Fetch replies for a specific comment from Trakt. "
+            "Supports optional pagination with 'page' parameter and "
+            "safety cap 'max_pages'."
+        ),
     )
     async def fetch_comment_replies_tool(
         comment_id: Annotated[

--- a/server/episodes/tools.py
+++ b/server/episodes/tools.py
@@ -443,7 +443,10 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_episode_summary"],
-        description="Fetch detailed information about a specific TV show episode, including overview, air date, runtime, and ratings.",
+        description=(
+            "Fetch detailed information about a specific TV show episode, "
+            "including overview, air date, runtime, and ratings."
+        ),
     )
     async def fetch_episode_summary_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -454,7 +457,9 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_episode_ratings"],
-        description="Fetch ratings and voting statistics for a specific TV show episode.",
+        description=(
+            "Fetch ratings and voting statistics for a specific TV show episode."
+        ),
     )
     async def fetch_episode_ratings_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -465,7 +470,10 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_episode_stats"],
-        description="Fetch engagement statistics for a specific TV show episode including watchers, plays, collectors, and comments.",
+        description=(
+            "Fetch engagement statistics for a specific TV show episode "
+            "including watchers, plays, collectors, and comments."
+        ),
     )
     async def fetch_episode_stats_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -476,7 +484,10 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_episode_people"],
-        description="Fetch cast and crew for a specific TV show episode, including character names and episode counts.",
+        description=(
+            "Fetch cast and crew for a specific TV show episode, "
+            "including character names and episode counts."
+        ),
     )
     async def fetch_episode_people_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -487,7 +498,10 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_episode_videos"],
-        description="Fetch videos (trailers, recaps, etc.) for a specific TV show episode. Set embed_markdown=False for simple links.",
+        description=(
+            "Fetch videos (trailers, recaps, etc.) for a specific TV show episode. "
+            "Set embed_markdown=False for simple links."
+        ),
     )
     async def fetch_episode_videos_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -502,7 +516,9 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_episode_watching"],
-        description="Fetch users currently watching a specific TV show episode right now.",
+        description=(
+            "Fetch users currently watching a specific TV show episode right now."
+        ),
     )
     async def fetch_episode_watching_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -513,7 +529,9 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_episode_translations"],
-        description="Fetch translations for a specific TV show episode in different languages.",
+        description=(
+            "Fetch translations for a specific TV show episode in different languages."
+        ),
     )
     async def fetch_episode_translations_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],

--- a/server/movies/resources.py
+++ b/server/movies/resources.py
@@ -253,7 +253,10 @@ def register_movie_resources(
     @mcp.resource(
         uri=MCP_RESOURCES["movies_watched"],
         name="movies_watched",
-        description="Most watched movies by unique users from Trakt in the current weekly period",
+        description=(
+            "Most watched movies by unique users from Trakt "
+            "in the current weekly period"
+        ),
         mime_type="text/markdown",
     )
     async def movies_watched_resource() -> str:

--- a/server/movies/tools.py
+++ b/server/movies/tools.py
@@ -128,7 +128,8 @@ async def fetch_favorited_movies(
     Args:
         limit: Maximum movies to return (default: 10, 0=fetch all). When page is
             None, this caps total results. When page is specified, this is per page.
-        period: Time period for favorite calculation (daily, weekly, monthly, yearly, all)
+        period: Time period for favorite calculation
+            (daily, weekly, monthly, yearly, all)
         page: Page number. If None, auto-paginates up to 'limit' total movies.
             If specified, returns that page with pagination metadata.
 
@@ -249,7 +250,8 @@ async def fetch_movie_ratings(movie_id: str) -> str:
     """Fetch ratings for a movie from Trakt.
 
     Args:
-        movie_id: Trakt ID, Trakt slug, or IMDB ID (e.g., '1', 'tron-legacy-2010', 'tt1104001')
+        movie_id: Trakt ID, Trakt slug, or IMDB ID
+            (e.g., '1', 'tron-legacy-2010', 'tt1104001')
 
     Returns:
         Information about movie ratings including average and distribution
@@ -299,14 +301,16 @@ async def fetch_movie_summary(movie_id: str, extended: bool = True) -> str:
     """Fetch movie summary from Trakt.
 
     Args:
-        movie_id: Trakt ID, Trakt slug, or IMDB ID (e.g., '1', 'tron-legacy-2010', 'tt1104001')
-        extended: If True, return comprehensive data with production status and metadata.
-                 If False, return basic movie information (title, year, IDs).
+        movie_id: Trakt ID, Trakt slug, or IMDB ID
+            (e.g., '1', 'tron-legacy-2010', 'tt1104001')
+        extended: If True, return comprehensive data with production status and
+                 metadata. If False, return basic movie information
+                 (title, year, IDs).
 
     Returns:
-        Movie information formatted as markdown. Extended mode includes production status,
-        ratings, metadata, and detailed information. Basic mode includes title, year,
-        and Trakt ID only.
+        Movie information formatted as markdown. Extended mode includes
+        production status, ratings, metadata, and detailed information.
+        Basic mode includes title, year, and Trakt ID only.
 
     Raises:
         InvalidParamsError: If movie_id is invalid
@@ -349,7 +353,8 @@ async def fetch_movie_videos(movie_id: str, embed_markdown: bool = True) -> str:
     """Fetch videos for a movie from Trakt.
 
     Args:
-        movie_id: Trakt ID, Trakt slug, or IMDB ID (e.g., '1', 'tron-legacy-2010', 'tt1104001')
+        movie_id: Trakt ID, Trakt slug, or IMDB ID
+            (e.g., '1', 'tron-legacy-2010', 'tt1104001')
         embed_markdown: Use embedded markdown syntax for video links
 
     Returns:
@@ -508,7 +513,10 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_trending_movies"],
-        description="Fetch trending movies from Trakt. Use page parameter for paginated results, or omit for all results.",
+        description=(
+            "Fetch trending movies from Trakt. "
+            "Use page parameter for paginated results, or omit for all results."
+        ),
     )
     async def fetch_trending_movies_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -518,7 +526,10 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_popular_movies"],
-        description="Fetch popular movies from Trakt. Use page parameter for paginated results, or omit for all results.",
+        description=(
+            "Fetch popular movies from Trakt. "
+            "Use page parameter for paginated results, or omit for all results."
+        ),
     )
     async def fetch_popular_movies_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -528,7 +539,10 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_favorited_movies"],
-        description="Fetch most favorited movies from Trakt. Use page parameter for paginated results, or omit for all results.",
+        description=(
+            "Fetch most favorited movies from Trakt. "
+            "Use page parameter for paginated results, or omit for all results."
+        ),
     )
     async def fetch_favorited_movies_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -542,7 +556,10 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_played_movies"],
-        description="Fetch most played movies from Trakt. Use page parameter for paginated results, or omit for all results.",
+        description=(
+            "Fetch most played movies from Trakt. "
+            "Use page parameter for paginated results, or omit for all results."
+        ),
     )
     async def fetch_played_movies_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -556,7 +573,10 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_watched_movies"],
-        description="Fetch most watched movies from Trakt. Use page parameter for paginated results, or omit for all results.",
+        description=(
+            "Fetch most watched movies from Trakt. "
+            "Use page parameter for paginated results, or omit for all results."
+        ),
     )
     async def fetch_watched_movies_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -570,7 +590,10 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_anticipated_movies"],
-        description="Fetch most anticipated movies from Trakt, sorted by list count. Use page parameter for paginated results, or omit for all results.",
+        description=(
+            "Fetch most anticipated movies from Trakt, sorted by list count. "
+            "Use page parameter for paginated results, or omit for all results."
+        ),
     )
     async def fetch_anticipated_movies_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -580,7 +603,10 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_boxoffice_movies"],
-        description="Fetch the top 10 grossing movies in the U.S. box office last weekend. Updated every Monday morning.",
+        description=(
+            "Fetch the top 10 grossing movies in the U.S. box office last weekend. "
+            "Updated every Monday morning."
+        ),
     )
     async def fetch_boxoffice_movies_tool() -> str:
         return await fetch_boxoffice_movies()
@@ -598,7 +624,12 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_movie_summary"],
-        description="Get movie summary from Trakt. Default behavior (extended=true): Returns comprehensive data including production status, ratings, genres, runtime, certification, and metadata. Basic mode (extended=false): Returns only title, year, and Trakt ID.",
+        description=(
+            "Get movie summary from Trakt. "
+            "Default behavior (extended=true): Returns comprehensive data including "
+            "production status, ratings, genres, runtime, certification, and metadata. "
+            "Basic mode (extended=false): Returns only title, year, and Trakt ID."
+        ),
     )
     async def fetch_movie_summary_tool(
         movie_id: Annotated[str, Field(min_length=1, description=MOVIE_ID_DESCRIPTION)],
@@ -612,7 +643,8 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         name=TOOL_NAMES["fetch_movie_videos"],
         description=(
             "Get videos (trailers, teasers, etc.) for a movie from Trakt. "
-            "Set embed_markdown=False to return simple links instead of YouTube iframes."
+            "Set embed_markdown=False to return simple links instead of "
+            "YouTube iframes."
         ),
     )
     async def fetch_movie_videos_tool(
@@ -629,7 +661,11 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_related_movies"],
-        description="Fetch movies related to a specific movie. Returns similar movies based on genres, themes, and viewer patterns. Use page parameter for paginated results, or omit for all results.",
+        description=(
+            "Fetch movies related to a specific movie. Returns similar movies "
+            "based on genres, themes, and viewer patterns. "
+            "Use page parameter for paginated results, or omit for all results."
+        ),
     )
     async def fetch_related_movies_tool(
         movie_id: Annotated[str, Field(min_length=1, description=MOVIE_ID_DESCRIPTION)],

--- a/server/progress/tools.py
+++ b/server/progress/tools.py
@@ -172,9 +172,12 @@ def register_progress_tools(
     @mcp.tool(
         name=PROGRESS_TOOLS["fetch_show_progress"],
         description=(
-            "Check if a user has watched a specific TV show and their progress through it. "
-            "Use this for: 'have I seen X?', 'did I finish X?', 'where am I in X?', 'what episode am I on?'. "
-            "Returns episodes watched, completion percentage, next episode to watch, and per-season breakdown. "
+            "Check if a user has watched a specific TV show and their progress "
+            "through it. "
+            "Use this for: 'have I seen X?', 'did I finish X?', "
+            "'where am I in X?', 'what episode am I on?'. "
+            "Returns episodes watched, completion percentage, next episode to "
+            "watch, and per-season breakdown. "
             "For listing all watched shows, use fetch_user_watched_shows instead. "
             "Requires OAuth authentication."
         ),

--- a/server/prompts/basic.py
+++ b/server/prompts/basic.py
@@ -15,7 +15,11 @@ async def discover_trending() -> list[dict[str, Any]]:
     return [
         {
             "role": "user",
-            "content": "Show me what movies and TV shows are trending on Trakt right now. Please include both movies and shows, and provide details about ratings, genres, and why they're popular.",
+            "content": (
+                "Show me what movies and TV shows are trending on Trakt right now. "
+                "Please include both movies and shows, and provide details about "
+                "ratings, genres, and why they're popular."
+            ),
         }
     ]
 
@@ -25,7 +29,11 @@ async def search_entertainment() -> list[dict[str, Any]]:
     return [
         {
             "role": "user",
-            "content": "Help me search for a movie or TV show. I'd like to find something specific by title, and also get recommendations based on what I'm looking for. What would you like to find?",
+            "content": (
+                "Help me search for a movie or TV show. I'd like to find something "
+                "specific by title, and also get recommendations based on what I'm "
+                "looking for. What would you like to find?"
+            ),
         }
     ]
 
@@ -50,7 +58,9 @@ def register_basic_prompts(mcp: FastMCP) -> tuple[Any, Any]:
 
     @mcp.prompt(
         name="search_entertainment",
-        description="Search for movies or TV shows by title with personalized recommendations",
+        description=(
+            "Search for movies or TV shows by title with personalized recommendations"
+        ),
     )
     async def search_entertainment_prompt() -> list[dict[str, Any]]:
         """Wrapper for search_entertainment prompt."""

--- a/server/recommendations/tools.py
+++ b/server/recommendations/tools.py
@@ -314,7 +314,8 @@ def register_recommendation_tools(
     @mcp.tool(
         name=TOOL_NAMES["hide_show_recommendation"],
         description=(
-            "Hide a TV show from future recommendations. Requires OAuth authentication. "
+            "Hide a TV show from future recommendations. "
+            "Requires OAuth authentication. "
             "Use Trakt ID, slug, or IMDB ID to identify the show."
         ),
     )

--- a/server/seasons/tools.py
+++ b/server/seasons/tools.py
@@ -458,7 +458,10 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_season_info"],
-        description="Fetch detailed information about a specific TV show season, including episode count, ratings, and air dates.",
+        description=(
+            "Fetch detailed information about a specific TV show season, "
+            "including episode count, ratings, and air dates."
+        ),
     )
     async def fetch_season_info_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -468,7 +471,10 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_season_episodes"],
-        description="Fetch all episodes for a specific TV show season with titles, ratings, and runtime.",
+        description=(
+            "Fetch all episodes for a specific TV show season "
+            "with titles, ratings, and runtime."
+        ),
     )
     async def fetch_season_episodes_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -478,7 +484,9 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_season_ratings"],
-        description="Fetch ratings and voting statistics for a specific TV show season.",
+        description=(
+            "Fetch ratings and voting statistics for a specific TV show season."
+        ),
     )
     async def fetch_season_ratings_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -488,7 +496,10 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_season_stats"],
-        description="Fetch engagement statistics for a specific TV show season including watchers, plays, collectors, and comments.",
+        description=(
+            "Fetch engagement statistics for a specific TV show season "
+            "including watchers, plays, collectors, and comments."
+        ),
     )
     async def fetch_season_stats_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -498,7 +509,10 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_season_people"],
-        description="Fetch cast and crew for a specific TV show season, including character names and episode counts.",
+        description=(
+            "Fetch cast and crew for a specific TV show season, "
+            "including character names and episode counts."
+        ),
     )
     async def fetch_season_people_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -508,7 +522,10 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_season_videos"],
-        description="Fetch videos (trailers, recaps, etc.) for a specific TV show season. Set embed_markdown=False for simple links.",
+        description=(
+            "Fetch videos (trailers, recaps, etc.) for a specific TV show season. "
+            "Set embed_markdown=False for simple links."
+        ),
     )
     async def fetch_season_videos_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -522,7 +539,9 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_season_watching"],
-        description="Fetch users currently watching a specific TV show season right now.",
+        description=(
+            "Fetch users currently watching a specific TV show season right now."
+        ),
     )
     async def fetch_season_watching_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -532,7 +551,9 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_season_translations"],
-        description="Fetch translations for a specific TV show season in different languages.",
+        description=(
+            "Fetch translations for a specific TV show season in different languages."
+        ),
     )
     async def fetch_season_translations_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],

--- a/server/shows/resources.py
+++ b/server/shows/resources.py
@@ -43,7 +43,9 @@ async def get_trending_shows() -> str:
 
 @handle_api_errors_func
 async def get_popular_shows() -> str:
-    """Returns the most popular shows from Trakt. Popularity is calculated using the rating percentage and the number of ratings.
+    """Returns the most popular shows from Trakt.
+
+    Popularity is calculated using the rating percentage and the number of ratings.
 
     Returns:
         Formatted markdown text with popular shows
@@ -55,7 +57,9 @@ async def get_popular_shows() -> str:
 
 @handle_api_errors_func
 async def get_favorited_shows() -> str:
-    """Returns the most favorited shows from Trakt in the specified time period, defaulting to weekly. All stats are relative to the specific time period.
+    """Returns the most favorited shows from Trakt in the specified time period.
+
+    Defaults to weekly. All stats are relative to the specific time period.
 
     Returns:
         Formatted markdown text with most favorited shows
@@ -233,7 +237,10 @@ def register_show_resources(
     @mcp.resource(
         uri=MCP_RESOURCES["shows_watched"],
         name="shows_watched",
-        description="Most watched TV shows by unique users from Trakt in the current weekly period",
+        description=(
+            "Most watched TV shows by unique users from Trakt "
+            "in the current weekly period"
+        ),
         mime_type="text/markdown",
     )
     async def shows_watched_resource() -> str:

--- a/server/shows/tools.py
+++ b/server/shows/tools.py
@@ -128,7 +128,8 @@ async def fetch_favorited_shows(
     Args:
         limit: Maximum shows to return (default: 10, 0=fetch all). When page is
             None, this caps total results. When page is specified, this is per page.
-        period: Time period for favorite calculation (daily, weekly, monthly, yearly, all)
+        period: Time period for favorite calculation
+            (daily, weekly, monthly, yearly, all)
         page: Page number. If None, auto-paginates up to 'limit' total shows.
             If specified, returns that page with pagination metadata.
 
@@ -235,7 +236,8 @@ async def fetch_show_ratings(show_id: str) -> str:
     """Fetch ratings for a show from Trakt.
 
     Args:
-        show_id: Trakt ID, Trakt slug, or IMDB ID (e.g., '1', 'breaking-bad', 'tt0903747')
+        show_id: Trakt ID, Trakt slug, or IMDB ID
+            (e.g., '1', 'breaking-bad', 'tt0903747')
 
     Returns:
         Information about show ratings including average and distribution
@@ -285,14 +287,16 @@ async def fetch_show_summary(show_id: str, extended: bool = True) -> str:
     """Fetch show summary from Trakt.
 
     Args:
-        show_id: Trakt ID, Trakt slug, or IMDB ID (e.g., '1', 'breaking-bad', 'tt0903747')
-        extended: If True, return comprehensive data with air times, production status and metadata.
-                 If False, return basic show information (title, year, IDs).
+        show_id: Trakt ID, Trakt slug, or IMDB ID
+            (e.g., '1', 'breaking-bad', 'tt0903747')
+        extended: If True, return comprehensive data with air times, production
+                 status and metadata. If False, return basic show information
+                 (title, year, IDs).
 
     Returns:
-        Show information formatted as markdown. Extended mode includes air times, production status,
-        ratings, metadata, and detailed information. Basic mode includes title, year,
-        and Trakt ID only.
+        Show information formatted as markdown. Extended mode includes air
+        times, production status, ratings, metadata, and detailed information.
+        Basic mode includes title, year, and Trakt ID only.
 
     Raises:
         InvalidParamsError: If show_id is invalid
@@ -371,7 +375,8 @@ async def fetch_show_videos(show_id: str, embed_markdown: bool = True) -> str:
         except Exception:
             # Best-effort title lookup — don't fail the operation
             logger.debug(
-                "Non-fatal exception during show title lookup; falling back to ID title.",
+                "Non-fatal exception during show title"
+                + " lookup; falling back to ID title.",
                 exc_info=True,
                 extra={"resource_id": show_id, "operation": "fetch_show_for_videos"},
             )
@@ -423,7 +428,8 @@ async def fetch_show_seasons(show_id: str) -> str:
     """Fetch all seasons for a show from Trakt.
 
     Args:
-        show_id: Trakt ID, Trakt slug, or IMDB ID (e.g., '1', 'breaking-bad', 'tt0903747')
+        show_id: Trakt ID, Trakt slug, or IMDB ID
+            (e.g., '1', 'breaking-bad', 'tt0903747')
 
     Returns:
         Formatted markdown with season details including episode counts and ratings
@@ -512,7 +518,10 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_trending_shows"],
-        description="Fetch trending TV shows from Trakt. Use page parameter for paginated results, or omit for all results.",
+        description=(
+            "Fetch trending TV shows from Trakt. "
+            "Use page parameter for paginated results, or omit for all results."
+        ),
     )
     async def fetch_trending_shows_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -522,7 +531,10 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_popular_shows"],
-        description="Fetch popular TV shows from Trakt. Use page parameter for paginated results, or omit for all results.",
+        description=(
+            "Fetch popular TV shows from Trakt. "
+            "Use page parameter for paginated results, or omit for all results."
+        ),
     )
     async def fetch_popular_shows_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -532,7 +544,10 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_favorited_shows"],
-        description="Fetch most favorited TV shows from Trakt. Use page parameter for paginated results, or omit for all results.",
+        description=(
+            "Fetch most favorited TV shows from Trakt. "
+            "Use page parameter for paginated results, or omit for all results."
+        ),
     )
     async def fetch_favorited_shows_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -546,7 +561,10 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_played_shows"],
-        description="Fetch most played TV shows from Trakt. Use page parameter for paginated results, or omit for all results.",
+        description=(
+            "Fetch most played TV shows from Trakt. "
+            "Use page parameter for paginated results, or omit for all results."
+        ),
     )
     async def fetch_played_shows_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -560,7 +578,10 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_watched_shows"],
-        description="Fetch most watched TV shows from Trakt. Use page parameter for paginated results, or omit for all results.",
+        description=(
+            "Fetch most watched TV shows from Trakt. "
+            "Use page parameter for paginated results, or omit for all results."
+        ),
     )
     async def fetch_watched_shows_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -574,7 +595,10 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_anticipated_shows"],
-        description="Fetch most anticipated TV shows from Trakt, sorted by list count. Use page parameter for paginated results, or omit for all results.",
+        description=(
+            "Fetch most anticipated TV shows from Trakt, sorted by list count. "
+            "Use page parameter for paginated results, or omit for all results."
+        ),
     )
     async def fetch_anticipated_shows_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -595,7 +619,13 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_show_summary"],
-        description="Get TV show summary from Trakt. Default behavior (extended=true): Returns comprehensive data including air times, production status, ratings, genres, runtime, network, and metadata. Basic mode (extended=false): Returns only title, year, and Trakt ID.",
+        description=(
+            "Get TV show summary from Trakt. "
+            "Default behavior (extended=true): Returns comprehensive data including "
+            "air times, production status, ratings, genres, runtime, network, and "
+            "metadata. Basic mode (extended=false): Returns only title, year, and "
+            "Trakt ID."
+        ),
     )
     async def fetch_show_summary_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -609,7 +639,8 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         name=TOOL_NAMES["fetch_show_videos"],
         description=(
             "Get videos (trailers, teasers, etc.) for a show from Trakt. "
-            "Set embed_markdown=False to return simple links instead of YouTube iframes."
+            "Set embed_markdown=False to return simple links instead of "
+            "YouTube iframes."
         ),
     )
     async def fetch_show_videos_tool(
@@ -626,7 +657,11 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_related_shows"],
-        description="Fetch TV shows related to a specific show. Returns similar shows based on genres, themes, and viewer patterns. Use page parameter for paginated results, or omit for all results.",
+        description=(
+            "Fetch TV shows related to a specific show. Returns similar shows "
+            "based on genres, themes, and viewer patterns. "
+            "Use page parameter for paginated results, or omit for all results."
+        ),
     )
     async def fetch_related_shows_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -637,7 +672,10 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
 
     @mcp.tool(
         name=TOOL_NAMES["fetch_show_seasons"],
-        description="Fetch all seasons for a TV show from Trakt, including episode counts, aired episodes, and ratings per season.",
+        description=(
+            "Fetch all seasons for a TV show from Trakt, including episode counts, "
+            "aired episodes, and ratings per season."
+        ),
     )
     async def fetch_show_seasons_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],

--- a/server/sync/tools.py
+++ b/server/sync/tools.py
@@ -303,7 +303,8 @@ async def remove_user_ratings(
 
     Args:
         rating_type: Type of content to unrate (movies, shows, seasons, episodes)
-        items: List of items to remove ratings from (no rating values needed, just identification)
+        items: List of items to remove ratings from (no rating values needed,
+            just identification)
 
     Returns:
         Summary of removed ratings with counts
@@ -363,7 +364,8 @@ async def fetch_user_watchlist(
     """Fetch authenticated user's watchlist from Trakt.
 
     Args:
-        watchlist_type: Type of watchlist items to fetch (all, movies, shows, seasons, episodes)
+        watchlist_type: Type of watchlist items to fetch
+            (all, movies, shows, seasons, episodes)
         sort_by: Field to sort by (rank, added, title, released, runtime, etc.)
         sort_how: Sort direction (asc, desc)
         page: Optional page number for pagination (1-based)
@@ -428,7 +430,8 @@ async def add_user_watchlist(
 
     Args:
         watchlist_type: Type of content to add (movies, shows, seasons, episodes)
-        items: List of items to add with identification info and optional notes (VIP only)
+        items: List of items to add with identification info and optional notes
+            (VIP only)
 
     Returns:
         Summary of added watchlist items with counts
@@ -490,7 +493,8 @@ async def remove_user_watchlist(
 
     Args:
         watchlist_type: Type of content to remove (movies, shows, seasons, episodes)
-        items: List of items to remove from watchlist (no notes needed, just identification)
+        items: List of items to remove from watchlist (no notes needed,
+            just identification)
 
     Returns:
         Summary of removed watchlist items with counts
@@ -779,7 +783,10 @@ def register_sync_tools(
 
     @mcp.tool(
         name=SYNC_TOOLS["add_user_ratings"],
-        description="Add new ratings for the authenticated user. Requires OAuth authentication.",
+        description=(
+            "Add new ratings for the authenticated user. "
+            "Requires OAuth authentication."
+        ),
     )
     async def add_user_ratings_tool(
         rating_type: Annotated[
@@ -798,7 +805,10 @@ def register_sync_tools(
 
     @mcp.tool(
         name=SYNC_TOOLS["remove_user_ratings"],
-        description="Remove ratings for the authenticated user. Requires OAuth authentication.",
+        description=(
+            "Remove ratings for the authenticated user. "
+            "Requires OAuth authentication."
+        ),
     )
     async def remove_user_ratings_tool(
         rating_type: Annotated[

--- a/server/user/resources.py
+++ b/server/user/resources.py
@@ -25,7 +25,11 @@ async def get_user_watched_shows() -> str:
     client: UserClient = UserClient()
 
     if not await client.ensure_authenticated():
-        return "# Authentication Required\n\nYou need to authenticate with Trakt to view your watched shows.\nUse the `start_device_auth` tool to begin authentication."
+        return (
+            "# Authentication Required\n\n"
+            "You need to authenticate with Trakt to view your watched shows.\n"
+            "Use the `start_device_auth` tool to begin authentication."
+        )
 
     shows = await client.get_user_watched_shows()
     return UserFormatters.format_user_watched_shows(shows)
@@ -42,7 +46,11 @@ async def get_user_watched_movies() -> str:
     client: UserClient = UserClient()
 
     if not await client.ensure_authenticated():
-        return "# Authentication Required\n\nYou need to authenticate with Trakt to view your watched movies.\nUse the `start_device_auth` tool to begin authentication."
+        return (
+            "# Authentication Required\n\n"
+            "You need to authenticate with Trakt to view your watched movies.\n"
+            "Use the `start_device_auth` tool to begin authentication."
+        )
 
     movies = await client.get_user_watched_movies()
     return UserFormatters.format_user_watched_movies(movies)
@@ -58,7 +66,10 @@ def register_user_resources(mcp: FastMCP) -> tuple[ResourceHandler, ResourceHand
     @mcp.resource(
         uri=MCP_RESOURCES["user_watched_shows"],
         name="user_watched_shows",
-        description="TV shows watched by the authenticated user from Trakt (requires authentication)",
+        description=(
+            "TV shows watched by the authenticated user from Trakt "
+            "(requires authentication)"
+        ),
         mime_type="text/markdown",
     )
     async def user_watched_shows_resource() -> str:
@@ -67,7 +78,10 @@ def register_user_resources(mcp: FastMCP) -> tuple[ResourceHandler, ResourceHand
     @mcp.resource(
         uri=MCP_RESOURCES["user_watched_movies"],
         name="user_watched_movies",
-        description="Movies watched by the authenticated user from Trakt (requires authentication)",
+        description=(
+            "Movies watched by the authenticated user from Trakt "
+            "(requires authentication)"
+        ),
         mime_type="text/markdown",
     )
     async def user_watched_movies_resource() -> str:

--- a/server/user/tools.py
+++ b/server/user/tools.py
@@ -153,9 +153,11 @@ def register_user_tools(mcp: FastMCP) -> tuple[ToolHandler, ToolHandler]:
     @mcp.tool(
         name=TOOL_NAMES["fetch_user_watched_shows"],
         description=(
-            "Fetch list of TV shows the user has watched, sorted by most recently watched. "
+            "Fetch list of TV shows the user has watched, "
+            "sorted by most recently watched. "
             "Returns show titles with last watched date and play counts. "
-            "Use for: 'what have I been watching?', 'my recent shows', 'list my watched shows'. "
+            "Use for: 'what have I been watching?', 'my recent shows', "
+            "'list my watched shows'. "
             "For checking a specific show (e.g., 'have I seen Breaking Bad?'), "
             "use fetch_history with history_type='shows' and item_id instead. "
             "Requires OAuth authentication."
@@ -177,9 +179,11 @@ def register_user_tools(mcp: FastMCP) -> tuple[ToolHandler, ToolHandler]:
     @mcp.tool(
         name=TOOL_NAMES["fetch_user_watched_movies"],
         description=(
-            "Fetch list of movies the user has watched, sorted by most recently watched. "
+            "Fetch list of movies the user has watched, "
+            "sorted by most recently watched. "
             "Returns movie titles with last watched date and play counts. "
-            "Use for: 'what movies have I watched?', 'my recent movies', 'list my watched movies'. "
+            "Use for: 'what movies have I watched?', 'my recent movies', "
+            "'list my watched movies'. "
             "For checking a specific movie (e.g., 'have I seen Inception?'), "
             "use fetch_history with history_type='movies' and item_id instead. "
             "Requires OAuth authentication."

--- a/tests/client/auth/test_auth_client.py
+++ b/tests/client/auth/test_auth_client.py
@@ -616,7 +616,8 @@ async def test_refresh_access_token_invalid_grant_clears_token(
 async def test_ensure_authenticated_valid_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test that ensure_authenticated returns True for valid token without refreshing."""
+    """Test that ensure_authenticated returns True for valid token without refreshing.
+    """
     current_time = int(time.time())
 
     monkeypatch.setenv("TRAKT_CLIENT_ID", "test_id")
@@ -717,7 +718,9 @@ async def test_ensure_authenticated_no_token(monkeypatch: pytest.MonkeyPatch) ->
 async def test_ensure_authenticated_expired_no_refresh_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test that ensure_authenticated returns False when token is expired but has no refresh token."""
+    """Test that ensure_authenticated returns False when token is expired but has no
+    refresh token.
+    """
     current_time = int(time.time())
 
     monkeypatch.setenv("TRAKT_CLIENT_ID", "test_id")

--- a/tests/client/auth/test_auth_flow.py
+++ b/tests/client/auth/test_auth_flow.py
@@ -142,7 +142,7 @@ async def test_device_token_pending_authorization():
 
         client = AuthClient()
 
-        # Try to get a token, should raise AuthorizationPendingError because authorization is pending
+        # Try to get a token, should raise AuthorizationPendingError (auth pending)
         with pytest.raises(AuthorizationPendingError) as exc_info:
             await client.get_device_token("device_code_123")
 
@@ -186,7 +186,7 @@ async def test_device_token_expired():
 
         client = AuthClient()
 
-        # Try to get a token, should raise InvalidParamsError because the code has expired
+        # Try to get a token, should raise InvalidParamsError because code has expired
         with pytest.raises(InvalidParamsError) as exc_info:
             await client.get_device_token("device_code_123")
 

--- a/tests/client/movies/test_movies_client.py
+++ b/tests/client/movies/test_movies_client.py
@@ -106,7 +106,12 @@ async def test_get_movie_extended():
             "tmdb": 20526,
         },
         "tagline": "The Game Has Changed.",
-        "overview": "Sam Flynn, the tech-savvy and daring son of Kevin Flynn, investigates his father's disappearance and is pulled into The Grid. With the help of a mysterious program named Quorra, Sam quests to stop evil dictator Clu from crossing into the real world.",
+        "overview": (
+            "Sam Flynn, the tech-savvy and daring son of Kevin Flynn, investigates"
+            " his father's disappearance and is pulled into The Grid. With the help"
+            " of a mysterious program named Quorra, Sam quests to stop evil dictator"
+            " Clu from crossing into the real world."
+        ),
         "released": "2010-12-16",
         "runtime": 125,
         "country": "us",

--- a/tests/client/movies/test_movies_pagination.py
+++ b/tests/client/movies/test_movies_pagination.py
@@ -485,11 +485,11 @@ async def test_multiple_pages_auto_paginate(
 async def test_auto_pagination_max_pages_returns_collected_items(
     trakt_env: None, patched_httpx_client: MagicMock
 ):
-    """Test that hitting max_pages with max_items set returns collected items without error.
+    """Test hitting max_pages with max_items set returns collected items without error.
 
-    When limit is passed (which sets max_items), hitting max_pages is graceful - we return
-    what we've collected so far. The error is only raised when max_items is None,
-    which can only happen at the base client level.
+    When limit is passed (which sets max_items), hitting max_pages is graceful -
+    we return what we have collected so far. The error is only raised when
+    max_items is None, which can only happen at the base client level.
     """
     # Create 101 mock pages (more than DEFAULT_MAX_PAGES which is 100)
     responses: list[MagicMock] = []

--- a/tests/client/shows/test_shows_client.py
+++ b/tests/client/shows/test_shows_client.py
@@ -146,7 +146,12 @@ async def test_get_show_extended():
             "tmdb": 1399,
         },
         "tagline": "Winter Is Coming",
-        "overview": "Game of Thrones is an American fantasy drama television series created for HBO by David Benioff and D. B. Weiss. It is an adaptation of A Song of Ice and Fire, George R. R. Martin's series of fantasy novels, the first of which is titled A Game of Thrones.",
+        "overview": (
+            "Game of Thrones is an American fantasy drama television series created"
+            " for HBO by David Benioff and D. B. Weiss. It is an adaptation of"
+            " A Song of Ice and Fire, George R. R. Martin's series of fantasy novels,"
+            " the first of which is titled A Game of Thrones."
+        ),
         "first_aired": "2011-04-18T01:00:00.000Z",
         "airs": {"day": "Sunday", "time": "21:00", "timezone": "America/New_York"},
         "runtime": 60,

--- a/tests/client/sync/test_ratings_client.py
+++ b/tests/client/sync/test_ratings_client.py
@@ -315,7 +315,7 @@ class TestSyncRatingsClient:
     async def test_remove_sync_ratings_unauthenticated(
         self, unauthenticated_client: SyncRatingsClient
     ) -> None:
-        """Test that unauthenticated remove requests raise AuthenticationRequiredError."""
+        """Test unauthenticated remove requests raise AuthenticationRequiredError."""
         request = TraktSyncRatingsRequest(
             movies=[TraktSyncRatingItem(ids=TraktIds(trakt=123))]
         )
@@ -471,7 +471,7 @@ class TestSyncRatingsClient:
     async def test_get_sync_ratings_unauthenticated(
         self, unauthenticated_client: SyncRatingsClient
     ) -> None:
-        """Test that unauthenticated paginated requests raise AuthenticationRequiredError."""
+        """Test unauthenticated paginated requests raise AuthenticationRequiredError."""
         pagination_params = PaginationParams(page=1, limit=10)
 
         with pytest.raises(AuthenticationRequiredError):

--- a/tests/client/sync/test_watchlist_client.py
+++ b/tests/client/sync/test_watchlist_client.py
@@ -445,7 +445,7 @@ class TestSyncWatchlistClient:
     async def test_remove_sync_watchlist_unauthenticated(
         self, unauthenticated_client: SyncWatchlistClient
     ) -> None:
-        """Test that unauthenticated remove requests raise AuthenticationRequiredError."""
+        """Test unauthenticated remove requests raise AuthenticationRequiredError."""
         request = TraktSyncWatchlistRequest(
             movies=[TraktSyncWatchlistItem(ids=TraktIds(trakt=123))]
         )

--- a/tests/config/api/test_api_constants.py
+++ b/tests/config/api/test_api_constants.py
@@ -35,7 +35,7 @@ class TestEffectiveLimit:
     """Test effective_limit function."""
 
     def test_positive_limit_returns_same_values(self) -> None:
-        """Test that positive limit returns the same value for both api_limit and max_items."""
+        """Test positive limit returns the same value for api_limit and max_items."""
         result = effective_limit(10)
         assert isinstance(result, EffectiveLimit)
         assert result.api_limit == 10

--- a/tests/config/mcp/test_mcp_resources.py
+++ b/tests/config/mcp/test_mcp_resources.py
@@ -51,7 +51,7 @@ class TestMcpResources:
             assert isinstance(MCP_RESOURCES[resource], str)
 
     def test_comment_resources_not_exist(self) -> None:
-        """Test comment-related resources are NOT present (they are tools, not resources)."""
+        """Test comment-related resources are NOT present (tools, not resources)."""
         comment_resources = [
             "comments_movie",
             "comments_show",
@@ -123,18 +123,21 @@ class TestMcpResources:
             assert MCP_RESOURCES[resource_key] == expected_uri
 
     def test_resources_only_contain_static_data(self) -> None:
-        """Test MCP resources only contain static data endpoints (not parameterized tools)."""
+        """Test MCP resources only contain static data endpoints (not parameterized)."""
         # Resources should be static data that doesn't require parameters
         for resource_key, resource_uri in MCP_RESOURCES.items():
             # Resources should not contain parameter placeholders
             assert ":id" not in resource_uri, (
-                f"Resource {resource_key} contains parameter placeholder, should be a tool instead"
+                f"Resource {resource_key} contains parameter placeholder,"
+                " should be a tool instead"
             )
             assert ":season" not in resource_uri, (
-                f"Resource {resource_key} contains parameter placeholder, should be a tool instead"
+                f"Resource {resource_key} contains parameter placeholder,"
+                " should be a tool instead"
             )
             assert ":episode" not in resource_uri, (
-                f"Resource {resource_key} contains parameter placeholder, should be a tool instead"
+                f"Resource {resource_key} contains parameter placeholder,"
+                " should be a tool instead"
             )
 
     def test_uri_consistency_with_categories(self) -> None:

--- a/tests/config/test_endpoints.py
+++ b/tests/config/test_endpoints.py
@@ -167,7 +167,7 @@ class TestEndpointUrlFormats:
             )
 
     def test_combined_endpoints_match_domain_modules(self) -> None:
-        """Test that combined TRAKT_ENDPOINTS matches domain-specific endpoint modules."""
+        """Test combined TRAKT_ENDPOINTS matches domain-specific endpoint modules."""
         # Import from domain-specific modules
         from config.endpoints.auth import AUTH_ENDPOINTS
         from config.endpoints.checkin import CHECKIN_ENDPOINTS

--- a/tests/config/test_resources.py
+++ b/tests/config/test_resources.py
@@ -51,7 +51,7 @@ class TestMcpResources:
             assert isinstance(MCP_RESOURCES[resource], str)
 
     def test_comment_resources_not_exist(self) -> None:
-        """Test comment-related resources are NOT present (they are tools, not resources)."""
+        """Test comment-related resources are NOT present (tools, not resources)."""
         comment_resources = [
             "comments_movie",
             "comments_show",
@@ -136,23 +136,27 @@ class TestResourceUriFormats:
         ]
         for tool in comment_tools:
             assert tool not in MCP_RESOURCES, (
-                f"Comment tool {tool} should not be in MCP_RESOURCES (it's a tool, not a resource)"
+                f"Comment tool {tool} should not be in MCP_RESOURCES"
+                " (it's a tool, not a resource)"
             )
 
     def test_resources_only_contain_static_data(self) -> None:
-        """Test MCP resources only contain static data endpoints (not parameterized tools)."""
+        """Test MCP resources only contain static data endpoints (not parameterized)."""
         # Resources should be static data that doesn't require parameters
         # All current resources are static lists (trending, popular, etc.)
         for resource_key, resource_uri in MCP_RESOURCES.items():
             # Resources should not contain parameter placeholders
             assert ":id" not in resource_uri, (
-                f"Resource {resource_key} contains parameter placeholder, should be a tool instead"
+                f"Resource {resource_key} contains parameter placeholder,"
+                " should be a tool instead"
             )
             assert ":season" not in resource_uri, (
-                f"Resource {resource_key} contains parameter placeholder, should be a tool instead"
+                f"Resource {resource_key} contains parameter placeholder,"
+                " should be a tool instead"
             )
             assert ":episode" not in resource_uri, (
-                f"Resource {resource_key} contains parameter placeholder, should be a tool instead"
+                f"Resource {resource_key} contains parameter placeholder,"
+                " should be a tool instead"
             )
 
     def test_uri_consistency_with_categories(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,7 +119,10 @@ def sample_show_data():
             "imdb": "tt0903747",
             "tmdb": "1396",
         },
-        "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer turns to manufacturing and selling methamphetamine.",
+        "overview": (
+            "A high school chemistry teacher diagnosed with inoperable lung cancer"
+            " turns to manufacturing and selling methamphetamine."
+        ),
     }
 
 
@@ -135,7 +138,11 @@ def sample_movie_data():
             "imdb": "tt1375666",
             "tmdb": "27205",
         },
-        "overview": "A thief who steals corporate secrets through the use of dream-sharing technology is given the inverse task of planting an idea into the mind of a C.E.O.",
+        "overview": (
+            "A thief who steals corporate secrets through the use of dream-sharing"
+            " technology is given the inverse task of planting an idea into the"
+            " mind of a C.E.O."
+        ),
     }
 
 
@@ -149,7 +156,10 @@ def sample_trending_shows():
                 "title": "Breaking Bad",
                 "year": 2008,
                 "ids": {"trakt": "1"},
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
             },
         },
         {
@@ -158,7 +168,10 @@ def sample_trending_shows():
                 "title": "Stranger Things",
                 "year": 2016,
                 "ids": {"trakt": "2"},
-                "overview": "When a young boy disappears, his mother, a police chief, and his friends must confront terrifying forces.",
+                "overview": (
+                    "When a young boy disappears, his mother, a police chief,"
+                    " and his friends must confront terrifying forces."
+                ),
             },
         },
     ]
@@ -174,7 +187,10 @@ def sample_trending_movies():
                 "title": "Inception",
                 "year": 2010,
                 "ids": {"trakt": "1"},
-                "overview": "A thief who steals corporate secrets through the use of dream-sharing technology.",
+                "overview": (
+                    "A thief who steals corporate secrets through the use"
+                    " of dream-sharing technology."
+                ),
             },
         },
         {
@@ -183,7 +199,10 @@ def sample_trending_movies():
                 "title": "The Dark Knight",
                 "year": 2008,
                 "ids": {"trakt": "2"},
-                "overview": "When the menace known as the Joker wreaks havoc and chaos on the people of Gotham.",
+                "overview": (
+                    "When the menace known as the Joker wreaks havoc and chaos"
+                    " on the people of Gotham."
+                ),
             },
         },
     ]

--- a/tests/integration/test_error_propagation.py
+++ b/tests/integration/test_error_propagation.py
@@ -42,7 +42,8 @@ class MockHttpErrorFactory(Protocol):
 
 
 class TestErrorPropagationThroughStack:
-    """Test error propagation through the complete Client → Tool → MCP → Response stack."""
+    """Test error propagation through the complete Client → Tool → MCP → Response stack.
+    """
 
     @pytest.fixture(autouse=True)
     def setup_context(self):
@@ -105,7 +106,8 @@ class TestErrorPropagationThroughStack:
             from server.search.tools import search_shows
 
             # The tool should raise a structured MCP error, not return a string
-            # For 400 validation errors, we expect InvalidParamsError, TraktValidationError, or InternalError
+            # For 400 errors, expect InvalidParamsError, TraktValidationError, or
+            # InternalError
             with pytest.raises(
                 (InvalidParamsError, TraktValidationError, InternalError)
             ) as exc_info:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -116,7 +116,10 @@ async def test_search_and_checkin_integration() -> None:
                 "title": "Breaking Bad",
                 "year": 2008,
                 "ids": {"trakt": 1, "slug": "breaking-bad"},
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
             },
         }
     ]
@@ -212,7 +215,10 @@ async def test_trending_shows_integration() -> None:
                 "title": "Breaking Bad",
                 "year": 2008,
                 "ids": {"trakt": 1, "slug": "breaking-bad"},
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
             },
         },
         {
@@ -221,7 +227,10 @@ async def test_trending_shows_integration() -> None:
                 "title": "Stranger Things",
                 "year": 2016,
                 "ids": {"trakt": 2, "slug": "stranger-things"},
-                "overview": "When a young boy disappears, his mother and friends must confront terrifying forces.",
+                "overview": (
+                    "When a young boy disappears, his mother and friends"
+                    " must confront terrifying forces."
+                ),
             },
         },
     ]

--- a/tests/integration/test_sync_ratings_flow.py
+++ b/tests/integration/test_sync_ratings_flow.py
@@ -780,14 +780,14 @@ async def test_fetch_user_ratings_backward_compatibility_integration(
 
             # Test without page parameter (non-paginated request)
             result = await fetch_user_ratings(rating_type="movies")
-            # Verify response format (pagination info is always present in response structure)
+            # Verify response format (pagination info is always present in response)
             assert "# Your Movies Ratings" in result
             assert "Found 3 rated movies on this page" in result
             assert "TRON: Legacy (2010)" in result
-            # Response will contain pagination metadata (with default values when no headers present)
+            # Response will contain pagination metadata (defaults with no headers)
             assert "📄" in result
 
-            # Verify NO pagination parameters were sent (following "Pagination Optional" pattern)
+            # Verify NO pagination parameters were sent (Pagination Optional pattern)
             call_args = mock_http_client.get.call_args
             call_kwargs = call_args[1]
             assert not call_kwargs.get("params")
@@ -837,7 +837,7 @@ async def test_fetch_user_ratings_pagination_error_handling_integration(
 async def test_fetch_user_ratings_pagination_authentication_flow_integration(
     authenticated_sync_client: SyncClient,
 ) -> None:
-    """Test that paginated requests require authentication just like regular requests."""
+    """Test that paginated requests require authentication like regular requests."""
 
     with patch.dict(
         os.environ,

--- a/tests/models/formatters/test_sync_ratings_formatter.py
+++ b/tests/models/formatters/test_sync_ratings_formatter.py
@@ -306,7 +306,7 @@ class TestSyncRatingsFormatters:
         assert "Long Running Show - S12E34: Big Numbers (1990)" in result
 
     def test_format_user_ratings_edge_case_single_digit_episode(self) -> None:
-        """Test SxxExx formatting with single-digit season and episode numbers (zero-padded)."""
+        """Test SxxExx formatting with single-digit season and episode (zero-padded)."""
         episode_rating = TraktSyncRating(
             rated_at=datetime.fromisoformat("2024-01-01T10:00:00.000+00:00"),
             rating=5,

--- a/tests/models/formatters/test_videos_formatter.py
+++ b/tests/models/formatters/test_videos_formatter.py
@@ -8,6 +8,12 @@ import pytest
 
 from models.formatters.videos import VideoFormatters
 
+_IFRAME_INSTRUCTION = (
+    "**ALWAYS:** Preserve iframe HTML below exactly as"
+    + " provided so videos embed and display properly"
+    + " in the response"
+)
+
 if TYPE_CHECKING:
     from models.types.api_responses import VideoResponse, VideoSite, VideoType
 
@@ -129,7 +135,7 @@ class TestVideoFormatters:
         assert video_id is None
 
     def test_extract_youtube_video_id_modern_share_urls(self):
-        """Test YouTube video ID extraction from modern share URLs with ?si= parameters."""
+        """Test YouTube video ID extraction from modern share URLs with ?si= params."""
         modern_urls = [
             "youtu.be/mcvLKldPM08?si=nOWNYgjPFPezp47c",
             "https://youtu.be/mcvLKldPM08?si=nOWNYgjPFPezp47c",
@@ -226,7 +232,8 @@ class TestVideoFormatters:
             "https://youtube.123/embed/ZbsiKjVAV28",  # Numeric TLD
             "https://youtube.c/embed/ZbsiKjVAV28",  # TLD too short
             "https://fakeyoutube.de/embed/ZbsiKjVAV28",  # Wrong base domain
-            "https://youtube.evil.de/embed/ZbsiKjVAV28",  # Extra subdomain before country
+            # Extra subdomain before country TLD
+            "https://youtube.evil.de/embed/ZbsiKjVAV28",
         ]
 
         for test_url in invalid_country_domains:
@@ -446,7 +453,7 @@ class TestVideoFormatters:
 
         # Check iframe embed
         assert (
-            "**ALWAYS:** Preserve iframe HTML below exactly as provided so videos embed and display properly in the response"
+            _IFRAME_INSTRUCTION
             in result
         )
         assert "<iframe" in result
@@ -487,7 +494,7 @@ class TestVideoFormatters:
 
         # Should not contain iframe or instructional text
         assert (
-            "**ALWAYS:** Preserve iframe HTML below exactly as provided so videos embed and display properly in the response"
+            _IFRAME_INSTRUCTION
             not in result
         )
         assert "<iframe" not in result
@@ -574,7 +581,7 @@ class TestVideoFormatters:
 
         # Should not contain iframe for non-YouTube
         assert (
-            "**ALWAYS:** Preserve iframe HTML below exactly as provided so videos embed and display properly in the response"
+            _IFRAME_INSTRUCTION
             not in result
         )
         assert "<iframe" not in result
@@ -619,12 +626,7 @@ class TestVideoFormatters:
         assert "## Teasers" in result
 
         # Check both videos have iframe embeds
-        assert (
-            result.count(
-                "**ALWAYS:** Preserve iframe HTML below exactly as provided so videos embed and display properly in the response"
-            )
-            == 1
-        )
+        assert result.count(_IFRAME_INSTRUCTION) == 1
         assert result.count("<iframe") == 2
 
     def test_format_videos_list_sorting_by_date(self):
@@ -713,7 +715,7 @@ class TestVideoFormatters:
 
         # Should fallback to simple link, not iframe
         assert (
-            "**ALWAYS:** Preserve iframe HTML below exactly as provided so videos embed and display properly in the response"
+            _IFRAME_INSTRUCTION
             not in result
         )
         assert "<iframe" not in result

--- a/tests/models/formatters/test_videos_formatter.py
+++ b/tests/models/formatters/test_videos_formatter.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 import pytest
 
 from models.formatters.videos import VideoFormatters
 
-_IFRAME_INSTRUCTION = (
+_IFRAME_INSTRUCTION: Final[str] = (
     "**ALWAYS:** Preserve iframe HTML below exactly as"
     + " provided so videos embed and display properly"
     + " in the response"

--- a/tests/models/test_media.py
+++ b/tests/models/test_media.py
@@ -57,7 +57,10 @@ class TestTraktShow:
                 imdb="tt0903747",
                 tmdb=1396,
             ),
-            overview="A high school chemistry teacher diagnosed with inoperable lung cancer.",
+            overview=(
+                "A high school chemistry teacher diagnosed"
+                " with inoperable lung cancer."
+            ),
         )
 
         assert show.title == "Breaking Bad"
@@ -157,7 +160,10 @@ class TestTraktMovie:
                 imdb="tt1375666",
                 tmdb=27205,
             ),
-            overview="A thief who steals corporate secrets through dream-sharing technology.",
+            overview=(
+                "A thief who steals corporate secrets"
+                " through dream-sharing technology."
+            ),
         )
 
         assert movie.title == "Inception"
@@ -526,7 +532,10 @@ class TestMediaModelIntegration:
                 imdb="tt0944947",
                 tmdb=1399,
             ),
-            overview="Seven noble families fight for control of the mythical land of Westeros.",
+            overview=(
+                "Seven noble families fight for control of the mythical"
+                " land of Westeros."
+            ),
         )
 
         # Test direct show creation
@@ -552,7 +561,10 @@ class TestMediaModelIntegration:
                 imdb="tt0468569",
                 tmdb=155,
             ),
-            overview="When the menace known as the Joker wreaks havoc and chaos on the people of Gotham.",
+            overview=(
+                "When the menace known as the Joker wreaks havoc and chaos"
+                " on the people of Gotham."
+            ),
         )
 
         # Test direct movie creation

--- a/tests/models/test_user_rating_identifier.py
+++ b/tests/models/test_user_rating_identifier.py
@@ -124,7 +124,8 @@ class TestUserRatingIdentifierValidation:
         assert "Rating item must include either an identifier" in error_msg
 
     def test_invalid_empty_strings_no_title_year(self) -> None:
-        """Test validation error when identifiers are empty strings and no title/year."""
+        """Test validation error when identifiers are empty strings and no title/year.
+        """
         with pytest.raises(ValidationError) as exc_info:
             UserRatingIdentifier(trakt_id="", imdb_id="", tmdb_id="")
 

--- a/tests/models/test_user_rating_request_item.py
+++ b/tests/models/test_user_rating_request_item.py
@@ -135,7 +135,8 @@ class TestUserRatingRequestItemValidation:
         assert "Rating item must include either an identifier" in error_msg
 
     def test_invalid_empty_strings_no_title_year(self) -> None:
-        """Test validation error when identifiers are empty strings and no title/year."""
+        """Test validation error when identifiers are empty strings and no title/year.
+        """
         with pytest.raises(ValidationError) as exc_info:
             UserRatingRequestItem(rating=8, trakt_id="", imdb_id="", tmdb_id="")
 

--- a/tests/models/types/test_pagination.py
+++ b/tests/models/types/test_pagination.py
@@ -319,7 +319,7 @@ class TestPaginatedResponse:
 
     def test_page_info_calculation_edge_cases(self) -> None:
         """Test edge cases in page info calculations."""
-        # Test case where data length is less than items_per_page due to filtering/deletion
+        # Test case where data length < items_per_page due to filtering/deletion
         metadata = PaginationMetadata(
             current_page=2, items_per_page=10, total_pages=2, total_items=15
         )

--- a/tests/models/user/test_user.py
+++ b/tests/models/user/test_user.py
@@ -26,7 +26,10 @@ class TestTraktUserShow:
             "title": "Breaking Bad",
             "year": 2008,
             "ids": {"trakt": "1", "slug": "breaking-bad"},
-            "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+            "overview": (
+                "A high school chemistry teacher diagnosed"
+                " with inoperable lung cancer."
+            ),
         }
 
         user_show_data: UserShowTestData = {
@@ -445,8 +448,8 @@ class TestTraktUserShow:
             "ids": {"trakt": "1"},
         }
 
-        # Test negative plays (currently allowed - model uses plain int, not constrained)
-        # Note: If domain requires non-negative counts, consider using conint(ge=0)
+        # Test negative plays (currently allowed - model uses plain int, unconstrained)
+        # Note: If domain requires non-negative counts, consider conint(ge=0)
         user_show = TraktUserShow(
             show=show_data,  # type: ignore[arg-type] # Testing: Type validation
             last_watched_at="2023-01-15T20:30:00Z",

--- a/tests/server/auth/test_auth_thread_safety.py
+++ b/tests/server/auth/test_auth_thread_safety.py
@@ -147,6 +147,6 @@ class TestAuthFlowThreadSafety:
             success_messages = [r for r in results if "Authentication Successful" in r]
             assert len(success_messages) >= 1
 
-            # The test verifies that concurrent access doesn't cause crashes or data corruption
-            # Multiple successes are OK - it means multiple coroutines authenticated before flow was cleared
-            # This is acceptable behavior as long as no errors occur
+            # Verifies concurrent access doesn't cause crashes or data corruption
+            # Multiple successes are OK - multiple coroutines may authenticate
+            # before flow is cleared; acceptable as long as no errors occur

--- a/tests/server/base/test_error_mixin.py
+++ b/tests/server/base/test_error_mixin.py
@@ -231,7 +231,7 @@ class TestErrorHandlingDecorator:
         assert "'user_name': 'john_doe'" in kwargs_str
 
     async def test_with_error_handling_returns_friendly_auth_message(self) -> None:
-        """Test AuthenticationRequiredError returns a friendly message, not raises."""
+        """Test AuthenticationRequiredError returns friendly message, does not raise."""
 
         @BaseToolErrorMixin.with_error_handling("test_operation")
         async def auth_failing_function() -> str:

--- a/tests/server/base/test_error_mixin.py
+++ b/tests/server/base/test_error_mixin.py
@@ -231,7 +231,7 @@ class TestErrorHandlingDecorator:
         assert "'user_name': 'john_doe'" in kwargs_str
 
     async def test_with_error_handling_returns_friendly_auth_message(self) -> None:
-        """Test that AuthenticationRequiredError returns a friendly message instead of raising."""
+        """Test AuthenticationRequiredError returns a friendly message, not raises."""
 
         @BaseToolErrorMixin.with_error_handling("test_operation")
         async def auth_failing_function() -> str:

--- a/tests/server/checkin/test_checkin_tools.py
+++ b/tests/server/checkin/test_checkin_tools.py
@@ -101,7 +101,7 @@ async def test_checkin_to_show_missing_info() -> None:
         mock_client = mock_client_class.return_value
         mock_client.ensure_authenticated = AsyncMock(return_value=True)
 
-        # Call the tool function with missing show_id and show_title - should raise error
+        # Call the tool function with missing show_id and show_title - expect error
         with pytest.raises(InvalidParamsError) as exc_info:
             await checkin_to_show(season=1, episode=1)
 

--- a/tests/server/movies/test_movies_resources.py
+++ b/tests/server/movies/test_movies_resources.py
@@ -26,7 +26,10 @@ async def test_get_trending_movies():
             "movie": {
                 "title": "Inception",
                 "year": 2010,
-                "overview": "A thief who steals corporate secrets through dream-sharing technology.",
+                "overview": (
+                    "A thief who steals corporate secrets"
+                    " through dream-sharing technology."
+                ),
             },
         }
     ]
@@ -58,7 +61,10 @@ async def test_get_popular_movies():
         {
             "title": "Inception",
             "year": 2010,
-            "overview": "A thief who steals corporate secrets through dream-sharing technology.",
+            "overview": (
+                "A thief who steals corporate secrets"
+                " through dream-sharing technology."
+            ),
         }
     ]
 
@@ -90,7 +96,10 @@ async def test_get_anticipated_movies():
             "movie": {
                 "title": "Inception",
                 "year": 2010,
-                "overview": "A thief who steals corporate secrets through dream-sharing technology.",
+                "overview": (
+                    "A thief who steals corporate secrets"
+                    " through dream-sharing technology."
+                ),
             },
         }
     ]

--- a/tests/server/movies/test_movies_tools.py
+++ b/tests/server/movies/test_movies_tools.py
@@ -1,7 +1,7 @@
 import asyncio
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -24,7 +24,7 @@ from utils.api.error_types import (
 )
 from utils.api.errors import InternalError
 
-_IFRAME_INSTRUCTION = (
+_IFRAME_INSTRUCTION: Final[str] = (
     "**ALWAYS:** Preserve iframe HTML below exactly as"
     + " provided so videos embed and display properly"
     + " in the response"

--- a/tests/server/movies/test_movies_tools.py
+++ b/tests/server/movies/test_movies_tools.py
@@ -24,6 +24,12 @@ from utils.api.error_types import (
 )
 from utils.api.errors import InternalError
 
+_IFRAME_INSTRUCTION = (
+    "**ALWAYS:** Preserve iframe HTML below exactly as"
+    + " provided so videos embed and display properly"
+    + " in the response"
+)
+
 
 @pytest.mark.asyncio
 async def test_fetch_trending_movies():
@@ -33,7 +39,10 @@ async def test_fetch_trending_movies():
             "movie": {
                 "title": "Inception",
                 "year": 2010,
-                "overview": "A thief who steals corporate secrets through dream-sharing technology.",
+                "overview": (
+                    "A thief who steals corporate secrets"
+                    " through dream-sharing technology."
+                ),
             },
         }
     ]
@@ -362,7 +371,7 @@ async def test_fetch_movie_videos_with_embeds():
         # Verify result content
         assert "# Videos for Test Movie" in result
         assert (
-            "**ALWAYS:** Preserve iframe HTML below exactly as provided so videos embed and display properly in the response"
+            _IFRAME_INSTRUCTION
             in result
         )
         assert "<iframe" in result
@@ -393,7 +402,7 @@ async def test_fetch_movie_videos_without_embeds():
 
         # Should not contain iframe or instructional text
         assert (
-            "**ALWAYS:** Preserve iframe HTML below exactly as provided so videos embed and display properly in the response"
+            _IFRAME_INSTRUCTION
             not in result
         )
         assert "<iframe" not in result

--- a/tests/server/search/test_search_tools.py
+++ b/tests/server/search/test_search_tools.py
@@ -23,7 +23,10 @@ async def test_search_shows():
             "show": {
                 "title": "Breaking Bad",
                 "year": 2008,
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
                 "ids": {"trakt": "1"},
             }
         }
@@ -61,7 +64,10 @@ async def test_search_shows_with_limit():
             "show": {
                 "title": "Breaking Bad",
                 "year": 2008,
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
                 "ids": {"trakt": "1"},
             }
         }
@@ -134,7 +140,10 @@ async def test_search_movies():
             "movie": {
                 "title": "Inception",
                 "year": 2010,
-                "overview": "A thief who steals corporate secrets through dream-sharing technology.",
+                "overview": (
+                    "A thief who steals corporate secrets"
+                    " through dream-sharing technology."
+                ),
                 "ids": {"trakt": "1"},
             }
         }
@@ -167,7 +176,10 @@ async def test_search_movies_with_limit():
             "movie": {
                 "title": "Inception",
                 "year": 2010,
-                "overview": "A thief who steals corporate secrets through dream-sharing technology.",
+                "overview": (
+                    "A thief who steals corporate secrets"
+                    " through dream-sharing technology."
+                ),
                 "ids": {"trakt": "1"},
             }
         }
@@ -241,7 +253,10 @@ async def test_search_shows_multiple_results():
             "show": {
                 "title": "Breaking Bad",
                 "year": 2008,
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
                 "ids": {"trakt": "1"},
             }
         },
@@ -249,7 +264,10 @@ async def test_search_shows_multiple_results():
             "show": {
                 "title": "Better Call Saul",
                 "year": 2015,
-                "overview": "The trials and tribulations of criminal lawyer Jimmy McGill.",
+                "overview": (
+                    "The trials and tribulations of criminal"
+                    " lawyer Jimmy McGill."
+                ),
                 "ids": {"trakt": "2"},
             }
         },
@@ -279,7 +297,10 @@ async def test_search_movies_multiple_results():
             "movie": {
                 "title": "Inception",
                 "year": 2010,
-                "overview": "A thief who steals corporate secrets through dream-sharing technology.",
+                "overview": (
+                    "A thief who steals corporate secrets"
+                    " through dream-sharing technology."
+                ),
                 "ids": {"trakt": "1"},
             }
         },

--- a/tests/server/shows/test_shows_resources.py
+++ b/tests/server/shows/test_shows_resources.py
@@ -29,7 +29,10 @@ async def test_get_trending_shows():
             "show": {
                 "title": "Breaking Bad",
                 "year": 2008,
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
             },
         }
     ]
@@ -61,7 +64,10 @@ async def test_get_popular_shows():
         {
             "title": "Breaking Bad",
             "year": 2008,
-            "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+            "overview": (
+                "A high school chemistry teacher diagnosed"
+                " with inoperable lung cancer."
+            ),
         }
     ]
 
@@ -92,7 +98,10 @@ async def test_get_favorited_shows():
             "show": {
                 "title": "Breaking Bad",
                 "year": 2008,
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
             }
         }
     ]
@@ -124,7 +133,10 @@ async def test_get_played_shows():
             "show": {
                 "title": "Breaking Bad",
                 "year": 2008,
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
             }
         }
     ]
@@ -156,7 +168,10 @@ async def test_get_watched_shows():
             "show": {
                 "title": "Breaking Bad",
                 "year": 2008,
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
             }
         }
     ]
@@ -189,7 +204,10 @@ async def test_get_anticipated_shows():
             "show": {
                 "title": "Breaking Bad",
                 "year": 2008,
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
             },
         }
     ]

--- a/tests/server/shows/test_shows_tools.py
+++ b/tests/server/shows/test_shows_tools.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+from typing import Final
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -29,7 +30,7 @@ from utils.api.error_types import (
 )
 from utils.api.errors import InternalError
 
-_IFRAME_INSTRUCTION = (
+_IFRAME_INSTRUCTION: Final[str] = (
     "**ALWAYS:** Preserve iframe HTML below exactly as"
     + " provided so videos embed and display properly"
     + " in the response"

--- a/tests/server/shows/test_shows_tools.py
+++ b/tests/server/shows/test_shows_tools.py
@@ -29,6 +29,12 @@ from utils.api.error_types import (
 )
 from utils.api.errors import InternalError
 
+_IFRAME_INSTRUCTION = (
+    "**ALWAYS:** Preserve iframe HTML below exactly as"
+    + " provided so videos embed and display properly"
+    + " in the response"
+)
+
 
 @pytest.mark.asyncio
 async def test_fetch_trending_shows():
@@ -38,7 +44,10 @@ async def test_fetch_trending_shows():
             "show": {
                 "title": "Breaking Bad",
                 "year": 2008,
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
             },
         }
     ]
@@ -62,7 +71,10 @@ async def test_fetch_popular_shows():
         {
             "title": "Breaking Bad",
             "year": 2008,
-            "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+            "overview": (
+                "A high school chemistry teacher diagnosed"
+                " with inoperable lung cancer."
+            ),
         }
     ]
 
@@ -87,7 +99,10 @@ async def test_fetch_favorited_shows():
             "show": {
                 "title": "Breaking Bad",
                 "year": 2008,
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
             }
         }
     ]
@@ -113,7 +128,10 @@ async def test_fetch_played_shows():
             "show": {
                 "title": "Breaking Bad",
                 "year": 2008,
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
             }
         }
     ]
@@ -139,7 +157,10 @@ async def test_fetch_watched_shows():
             "show": {
                 "title": "Breaking Bad",
                 "year": 2008,
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
             }
         }
     ]
@@ -496,7 +517,7 @@ async def test_fetch_show_videos_with_embeds():
         # Verify result content
         assert "# Videos for Test Show" in result
         assert (
-            "**ALWAYS:** Preserve iframe HTML below exactly as provided so videos embed and display properly in the response"
+            _IFRAME_INSTRUCTION
             in result
         )
         assert "<iframe" in result
@@ -527,7 +548,7 @@ async def test_fetch_show_videos_without_embeds():
 
         # Should not contain iframe or instructional text
         assert (
-            "**ALWAYS:** Preserve iframe HTML below exactly as provided so videos embed and display properly in the response"
+            _IFRAME_INSTRUCTION
             not in result
         )
         assert "<iframe" not in result

--- a/tests/server/sync/test_ratings_tools.py
+++ b/tests/server/sync/test_ratings_tools.py
@@ -124,7 +124,7 @@ async def test_fetch_user_ratings_with_rating_filter() -> None:
         assert "# Your Shows Ratings (filtered to rating 10)" in result
         assert "Found 1 rated show on this page" in result
 
-        # Verify client was called with rating filter (no pagination when no page specified)
+        # Verify client called with rating filter (no pagination when no page specified)
         mock_client.get_sync_ratings.assert_called_once_with(
             "shows", 10, pagination=None
         )

--- a/tests/server/user/test_user_resources.py
+++ b/tests/server/user/test_user_resources.py
@@ -20,7 +20,10 @@ async def test_get_user_watched_shows_authenticated():
             "show": {
                 "title": "Breaking Bad",
                 "year": 2008,
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
             },
             "last_watched_at": "2023-01-15T20:30:00Z",
             "plays": 5,
@@ -78,7 +81,10 @@ async def test_get_user_watched_movies_authenticated():
             "movie": {
                 "title": "Inception",
                 "year": 2010,
-                "overview": "A thief who steals corporate secrets through dream-sharing technology.",
+                "overview": (
+                    "A thief who steals corporate secrets"
+                    " through dream-sharing technology."
+                ),
             },
             "last_watched_at": "2023-02-15T20:30:00Z",
             "plays": 3,

--- a/tests/server/user/test_user_tools.py
+++ b/tests/server/user/test_user_tools.py
@@ -21,7 +21,10 @@ async def test_fetch_user_watched_shows_authenticated():
             "show": {
                 "title": "Breaking Bad",
                 "year": 2008,
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
             },
             "last_watched_at": "2023-01-15T20:30:00Z",
             "plays": 5,
@@ -54,7 +57,10 @@ async def test_fetch_user_watched_movies_authenticated():
             "movie": {
                 "title": "Inception",
                 "year": 2010,
-                "overview": "A thief who steals corporate secrets through dream-sharing technology.",
+                "overview": (
+                    "A thief who steals corporate secrets"
+                    " through dream-sharing technology."
+                ),
             },
             "last_watched_at": "2023-02-15T20:30:00Z",
             "plays": 3,
@@ -87,7 +93,10 @@ async def test_fetch_user_watched_shows_limit_zero():
             "show": {
                 "title": "Breaking Bad",
                 "year": 2008,
-                "overview": "A high school chemistry teacher diagnosed with inoperable lung cancer.",
+                "overview": (
+                    "A high school chemistry teacher diagnosed"
+                    " with inoperable lung cancer."
+                ),
             },
             "last_watched_at": "2023-01-15T20:30:00Z",
             "plays": 5,
@@ -129,7 +138,10 @@ async def test_fetch_user_watched_movies_limit_zero():
             "movie": {
                 "title": "Inception",
                 "year": 2010,
-                "overview": "A thief who steals corporate secrets through dream-sharing technology.",
+                "overview": (
+                    "A thief who steals corporate secrets"
+                    " through dream-sharing technology."
+                ),
             },
             "last_watched_at": "2023-02-15T20:30:00Z",
             "plays": 3,
@@ -138,7 +150,10 @@ async def test_fetch_user_watched_movies_limit_zero():
             "movie": {
                 "title": "The Matrix",
                 "year": 1999,
-                "overview": "A computer hacker learns from mysterious rebels about the true nature of reality.",
+                "overview": (
+                    "A computer hacker learns from mysterious rebels"
+                    " about the true nature of reality."
+                ),
             },
             "last_watched_at": "2023-02-10T19:45:00Z",
             "plays": 2,

--- a/tests/test_mcp_compliance.py
+++ b/tests/test_mcp_compliance.py
@@ -306,8 +306,8 @@ class TestMCPCompliance:
         # Should fail with proper error response
         assert result.returncode != 0, "Invalid method should return error"
 
-        # Error should be properly formatted (MCP inspector handles JSON-RPC error format)
-        # The fact that we get a structured error response indicates compliance
+        # Error should be properly formatted (MCP inspector handles JSON-RPC format)
+        # Getting a structured error response indicates compliance
 
 
 class TestMCPFunctionalCompliance:
@@ -397,7 +397,8 @@ class TestMCPSpecificationDetails:
 
     def test_mcp_message_format(self) -> None:
         """Test that messages follow MCP format specification."""
-        # MCP inspector validates message format - successful communication indicates compliance
+        # MCP inspector validates message format - successful communication indicates
+        # compliance
         cmd = [
             "npx",
             "@modelcontextprotocol/inspector",

--- a/tests/utils/api/test_errors.py
+++ b/tests/utils/api/test_errors.py
@@ -213,7 +213,7 @@ class TestHandleApiErrorsDecorator:
     async def test_http_status_error_is_mapped_to_server_error(
         self, mock_async_func: AsyncMock
     ) -> None:
-        """Decorator delegates HTTPStatusError to the handler and raises TraktServerError."""
+        """Decorator delegates HTTPStatusError to handler, raises TraktServerError."""
         mock_response = MagicMock()
         mock_response.status_code = 500
         mock_response.text = "Internal Server Error"
@@ -448,7 +448,7 @@ class TestDecoratorIntegration:
 
     @pytest.mark.asyncio
     async def test_auth_error_returns_friendly_message(self) -> None:
-        """Test that AuthenticationRequiredError is caught and returns a friendly message."""
+        """Test AuthenticationRequiredError is caught and returns a friendly message."""
 
         @handle_api_errors_func
         async def test_func() -> str:

--- a/tests/utils/api/test_responses.py
+++ b/tests/utils/api/test_responses.py
@@ -103,8 +103,8 @@ class TestFormatErrorResponse:
         test_messages = [
             "Normal error",
             "",
-            "Success message",  # Even if message says success, error flag should be True
-            "Error: False",  # Even if message contains "False", error flag should be True
+            "Success message",  # Even if message says success, error flag is True
+            "Error: False",  # Even if message contains "False", error flag is True
         ]
 
         for message in test_messages:
@@ -196,13 +196,17 @@ class TestHelpersIntegration:
             pytest.fail("Error response should be JSON serializable")
 
     def test_format_error_response_consistent_with_error_handling(self) -> None:
-        """Test that error response format is consistent with error handling patterns."""
+        """Test that error response format is consistent with error handling patterns.
+        """
         # This test ensures the helper integrates well with the decorator error handling
         common_error_messages = [
             "Error: Unauthorized. Please check your Trakt API credentials.",
             "Error: The requested resource was not found.",
             "Error: Rate limit exceeded. Please try again later.",
-            "Error: Unable to connect to Trakt API. Please check your internet connection.",
+            (
+                "Error: Unable to connect to Trakt API."
+                " Please check your internet connection."
+            ),
             "Error: An unexpected error occurred: ValueError",
         ]
 

--- a/utils/api/errors.py
+++ b/utils/api/errors.py
@@ -119,8 +119,9 @@ def handle_api_errors(
 ) -> Callable[Concatenate[Any, ...], Awaitable[Any]]:
     """Handle API errors for class methods with perfect type inference.
 
-    This decorator is specifically designed for methods (functions with self/cls parameter).
-    For standalone functions, use @handle_api_errors_func instead.
+    This decorator is specifically designed for methods (functions with
+    self/cls parameter). For standalone functions, use @handle_api_errors_func
+    instead.
 
     Args:
         method: The async method to wrap
@@ -176,7 +177,8 @@ def handle_api_errors(
                 extra=error_data,
             )
             raise InternalError(
-                "Unable to connect to Trakt API. Please check your internet connection.",
+                "Unable to connect to Trakt API. "
+                + "Please check your internet connection.",
                 data=error_data,
             ) from e
         except MCPError:
@@ -235,8 +237,8 @@ def handle_api_errors_func(
 ) -> Callable[..., Awaitable[Any]]:
     """Handle API errors for standalone functions with perfect type inference.
 
-    This decorator is specifically designed for standalone functions (no self/cls parameter).
-    For class methods, use @handle_api_errors instead.
+    This decorator is specifically designed for standalone functions
+    (no self/cls parameter). For class methods, use @handle_api_errors instead.
 
     Note: Unlike @handle_api_errors, this decorator does NOT auto-clear authentication
     tokens on 401 responses because standalone functions don't have access to a client
@@ -291,7 +293,8 @@ def handle_api_errors_func(
                 extra=error_data,
             )
             raise InternalError(
-                "Unable to connect to Trakt API. Please check your internet connection.",
+                "Unable to connect to Trakt API. "
+                + "Please check your internet connection.",
                 data=error_data,
             ) from e
         except MCPError as e:

--- a/utils/api/structured_logging.py
+++ b/utils/api/structured_logging.py
@@ -86,7 +86,8 @@ class StructuredFormatter(logging.Formatter):
         }
 
         # Add context information if available using type-safe approach
-        # Note: We can safely treat record as extended since ContextFilter adds the attributes
+        # Note: We can safely treat record as extended since ContextFilter
+        # adds the attributes
 
         correlation_id = getattr(record, "correlation_id", None)
         if correlation_id:


### PR DESCRIPTION
Remove E501 from ruff ignore list so line-too-long is actively enforced. Fix all violations across 73 files by wrapping long strings, comments, docstrings, and code to fit within the 88-char limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reflowed and improved wording/line-wrapping across many API, client, and tool descriptions for clearer documentation.
* **Chores**
  * Tightened linting to enforce stricter line-length handling.
* **Style**
  * Adjusted user-facing instruction and status message formatting for improved readability (line breaks and punctuation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->