### PR TITLE
fix: sync history reliability

### DIFF
--- a/models/formatters/sync_history.py
+++ b/models/formatters/sync_history.py
@@ -149,24 +149,23 @@ class SyncHistoryFormatters:
             counts = summary.deleted
 
         if counts:
-            total = getattr(counts, content_type, 0)
+            # Sum all non-zero counts — the API may report deletions
+            # under a different type (e.g., episodes when removing a show)
+            type_breakdown: list[str] = []
+            total = 0
+            for type_name in ("movies", "shows", "seasons", "episodes"):
+                count = getattr(counts, type_name, 0)
+                if count > 0:
+                    total += count
+                    type_breakdown.append(f"{type_name.title()}: {count}")
+
             if total > 0:
                 preposition = "to" if operation == "added" else "from"
                 result += (
                     f"Successfully {operation} **{total}** "
-                    f"{content_type} {preposition} watch history.\n\n"
+                    f"item{'s' if total != 1 else ''} "
+                    f"{preposition} watch history.\n\n"
                 )
-
-                # Show breakdown by type if multiple types were processed
-                type_breakdown: list[str] = []
-                if counts.movies > 0:
-                    type_breakdown.append(f"Movies: {counts.movies}")
-                if counts.shows > 0:
-                    type_breakdown.append(f"Shows: {counts.shows}")
-                if counts.seasons > 0:
-                    type_breakdown.append(f"Seasons: {counts.seasons}")
-                if counts.episodes > 0:
-                    type_breakdown.append(f"Episodes: {counts.episodes}")
 
                 if len(type_breakdown) > 1:
                     result += "### Breakdown by Type\n"

--- a/models/formatters/sync_history.py
+++ b/models/formatters/sync_history.py
@@ -161,10 +161,15 @@ class SyncHistoryFormatters:
 
             if total > 0:
                 preposition = "to" if operation == "added" else "from"
+                if len(type_breakdown) == 1:
+                    label = type_breakdown[0].split(":")[0].lower()
+                    if total == 1:
+                        label = label.rstrip("s")
+                else:
+                    label = "item" if total == 1 else "items"
                 result += (
                     f"Successfully {operation} **{total}** "
-                    f"item{'s' if total != 1 else ''} "
-                    f"{preposition} watch history.\n\n"
+                    f"{label} {preposition} watch history.\n\n"
                 )
 
                 if len(type_breakdown) > 1:

--- a/models/sync/history.py
+++ b/models/sync/history.py
@@ -61,10 +61,10 @@ class TraktHistoryItem(BaseModel):
 class TraktHistoryRequest(BaseModel):
     """Request model for adding/removing history items."""
 
-    movies: Annotated[list[TraktHistoryItem], Field(default_factory=list)]
-    shows: Annotated[list[TraktHistoryItem], Field(default_factory=list)]
-    seasons: Annotated[list[TraktHistoryItem], Field(default_factory=list)]
-    episodes: Annotated[list[TraktHistoryItem], Field(default_factory=list)]
+    movies: list[TraktHistoryItem] | None = None
+    shows: list[TraktHistoryItem] | None = None
+    seasons: list[TraktHistoryItem] | None = None
+    episodes: list[TraktHistoryItem] | None = None
 
 
 class HistorySummaryCount(BaseModel):

--- a/models/types/ids.py
+++ b/models/types/ids.py
@@ -39,7 +39,7 @@ class TraktIds(BaseModel):
     @classmethod
     def validate_slug(cls, v: object) -> str | None:
         """Validate slug format (lowercase alphanumerics and hyphens)."""
-        if v is None:
+        if v is None or v == "":
             return None
         if isinstance(v, str):
             if re.match(r"^[a-z0-9]+(?:-[a-z0-9]+)*$", v):
@@ -50,8 +50,12 @@ class TraktIds(BaseModel):
     @field_validator("imdb", mode="before")
     @classmethod
     def validate_imdb_format(cls, v: object) -> str | None:
-        """Validate IMDB ID format (tt + digits)."""
-        if v is None:
+        """Validate IMDB ID format (tt + digits).
+
+        The Trakt API sometimes returns empty strings for imdb IDs
+        on episodes that lack an IMDB entry. Treat these as None.
+        """
+        if v is None or v == "":
             return None
         if isinstance(v, str):
             if re.match(r"^tt\d+$", v):

--- a/server/sync/tools.py
+++ b/server/sync/tools.py
@@ -8,6 +8,7 @@ from typing import Annotated, Any, ClassVar, Literal
 from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel, Field, field_validator
 
+from client.shows.seasons import ShowSeasonsClient
 from client.sync.client import SyncClient
 from config.api import DEFAULT_LIMIT
 from config.mcp.descriptions import (
@@ -37,6 +38,7 @@ from models.formatters.sync_watchlist import SyncWatchlistFormatters
 from models.sync.history import (
     HistoryQueryParams,
     HistorySummary,
+    HistorySummaryCount,
     TraktHistoryItem,
     TraktHistoryRequest,
 )
@@ -58,6 +60,104 @@ from server.base import BaseToolErrorMixin, IdentifierValidatorMixin
 from utils.api.errors import MCPError, handle_api_errors_func
 
 logger = logging.getLogger("trakt_mcp")
+
+
+def _aggregate_summary(
+    target: HistorySummary, source: HistorySummary, operation: str
+) -> None:
+    """Aggregate counts from source into target summary in-place.
+
+    Args:
+        target: Summary to accumulate into
+        source: Summary with new counts to add
+        operation: "added" or "deleted" — which count field to aggregate
+    """
+    src_counts = getattr(source, operation, None)
+    if src_counts is None:
+        return
+
+    tgt_counts = getattr(target, operation, None)
+    if tgt_counts is None:
+        tgt_counts = HistorySummaryCount()
+        setattr(target, operation, tgt_counts)
+
+    for field in ("movies", "shows", "seasons", "episodes"):
+        new_val = getattr(tgt_counts, field) + getattr(src_counts, field)
+        setattr(tgt_counts, field, new_val)
+
+    # Aggregate not_found lists
+    if source.not_found:
+        for field in ("movies", "shows", "seasons", "episodes"):
+            getattr(target.not_found, field).extend(getattr(source.not_found, field))
+
+
+async def _get_show_season_ids(show_id: str) -> list[int]:
+    """Fetch Trakt season IDs for a show, excluding specials (season 0).
+
+    Args:
+        show_id: Trakt show ID or slug
+
+    Returns:
+        List of Trakt season IDs
+    """
+    seasons_client = ShowSeasonsClient()
+    seasons = await seasons_client.get_seasons(show_id)
+    return [s["ids"]["trakt"] for s in seasons if s["number"] > 0]
+
+
+async def _batch_show_history_op(
+    client_method: Callable[[TraktHistoryRequest], Awaitable[HistorySummary]],
+    show_items: list[TraktHistoryItem],
+    operation: str,
+) -> HistorySummary:
+    """Execute a history add/remove for shows by batching per-season.
+
+    Large shows (100+ episodes) cause Trakt API 504 gateway timeouts.
+    This sends one request per season to keep each call small.
+
+    Args:
+        client_method: The client add_to_history or remove_from_history method
+        show_items: List of show items to process
+        operation: "added" or "deleted" — for aggregating the correct counts
+
+    Returns:
+        Aggregated HistorySummary across all season batches
+    """
+    combined = HistorySummary()
+
+    for item in show_items:
+        show_id = str(item.ids.trakt) if item.ids and item.ids.trakt else None
+        if show_id is None and item.ids and item.ids.slug:
+            show_id = item.ids.slug
+
+        if show_id is None:
+            # No resolvable ID — send as-is and hope for the best
+            request = TraktHistoryRequest(shows=[item])
+            result = await client_method(request)
+            _aggregate_summary(combined, result, operation)
+            continue
+
+        try:
+            season_ids = await _get_show_season_ids(show_id)
+        except Exception:
+            logger.warning(
+                "Failed to fetch seasons for show %s, sending as single request",
+                show_id,
+            )
+            request = TraktHistoryRequest(shows=[item])
+            result = await client_method(request)
+            _aggregate_summary(combined, result, operation)
+            continue
+
+        for season_id in season_ids:
+            request = TraktHistoryRequest(
+                seasons=[TraktHistoryItem(ids=TraktIds(trakt=season_id))]
+            )
+            result = await client_method(request)
+            _aggregate_summary(combined, result, operation)
+
+    return combined
+
 
 WatchlistSortField = Literal[
     "rank",
@@ -661,16 +761,21 @@ async def add_to_history(
         ids_dict = dict(item.build_ids_dict())
         history_items.append(
             TraktHistoryItem(
-                ids=TraktIds.model_validate(ids_dict),
+                ids=TraktIds.model_validate(ids_dict) if ids_dict else None,
                 title=item.title,
                 year=item.year,
                 watched_at=item.watched_at,
             )
         )
 
-    request = TraktHistoryRequest(**{history_type: history_items})
-
-    summary: HistorySummary = await client.add_to_history(request)
+    # For shows, batch per-season to avoid Trakt API gateway timeouts
+    if history_type == "shows":
+        summary = await _batch_show_history_op(
+            client.add_to_history, history_items, "added"
+        )
+    else:
+        request = TraktHistoryRequest(**{history_type: history_items})
+        summary = await client.add_to_history(request)
 
     # Handle transitional case where API returns error strings
     if isinstance(summary, str):
@@ -711,15 +816,20 @@ async def remove_from_history(
         ids_dict = dict(item.build_ids_dict())
         history_items.append(
             TraktHistoryItem(
-                ids=TraktIds.model_validate(ids_dict),
+                ids=TraktIds.model_validate(ids_dict) if ids_dict else None,
                 title=item.title,
                 year=item.year,
             )
         )
 
-    request = TraktHistoryRequest(**{history_type: history_items})
-
-    summary: HistorySummary = await client.remove_from_history(request)
+    # For shows, batch per-season to avoid Trakt API gateway timeouts
+    if history_type == "shows":
+        summary = await _batch_show_history_op(
+            client.remove_from_history, history_items, "deleted"
+        )
+    else:
+        request = TraktHistoryRequest(**{history_type: history_items})
+        summary = await client.remove_from_history(request)
 
     # Handle transitional case where API returns error strings
     if isinstance(summary, str):

--- a/server/sync/tools.py
+++ b/server/sync/tools.py
@@ -131,7 +131,7 @@ async def _batch_show_history_op(
             show_id = item.ids.slug
 
         if show_id is None:
-            # No resolvable ID — send as-is and hope for the best
+            # No resolvable ID — send the show item directly
             request = TraktHistoryRequest(shows=[item])
             result = await client_method(request)
             _aggregate_summary(combined, result, operation)
@@ -149,12 +149,30 @@ async def _batch_show_history_op(
             _aggregate_summary(combined, result, operation)
             continue
 
+        # Process seasons sequentially to avoid Trakt API rate-limit pressure
+        failed_seasons: list[int] = []
         for season_id in season_ids:
             request = TraktHistoryRequest(
                 seasons=[TraktHistoryItem(ids=TraktIds(trakt=season_id))]
             )
-            result = await client_method(request)
-            _aggregate_summary(combined, result, operation)
+            try:
+                result = await client_method(request)
+                _aggregate_summary(combined, result, operation)
+            except Exception:
+                logger.warning(
+                    "Failed to process season %s for show %s",
+                    season_id,
+                    show_id,
+                )
+                failed_seasons.append(season_id)
+
+        if failed_seasons:
+            logger.warning(
+                "Show %s: %d of %d seasons failed",
+                show_id,
+                len(failed_seasons),
+                len(season_ids),
+            )
 
     return combined
 

--- a/server/sync/tools.py
+++ b/server/sync/tools.py
@@ -134,6 +134,13 @@ async def _batch_show_history_op(
             # No resolvable ID — send the show item directly
             request = TraktHistoryRequest(shows=[item])
             result = await client_method(request)
+            if isinstance(result, str):
+                BaseToolErrorMixin.handle_api_string_error(
+                    resource_type="sync_history_show",
+                    resource_id="unknown",
+                    error_message=result,
+                    operation=operation,
+                )
             _aggregate_summary(combined, result, operation)
             continue
 
@@ -146,6 +153,30 @@ async def _batch_show_history_op(
             )
             request = TraktHistoryRequest(shows=[item])
             result = await client_method(request)
+            if isinstance(result, str):
+                BaseToolErrorMixin.handle_api_string_error(
+                    resource_type="sync_history_show",
+                    resource_id=show_id,
+                    error_message=result,
+                    operation=operation,
+                )
+            _aggregate_summary(combined, result, operation)
+            continue
+
+        if not season_ids:
+            logger.warning(
+                "No seasons found for show %s, sending as single request",
+                show_id,
+            )
+            request = TraktHistoryRequest(shows=[item])
+            result = await client_method(request)
+            if isinstance(result, str):
+                BaseToolErrorMixin.handle_api_string_error(
+                    resource_type="sync_history_show",
+                    resource_id=show_id,
+                    error_message=result,
+                    operation=operation,
+                )
             _aggregate_summary(combined, result, operation)
             continue
 
@@ -153,10 +184,22 @@ async def _batch_show_history_op(
         failed_seasons: list[int] = []
         for season_id in season_ids:
             request = TraktHistoryRequest(
-                seasons=[TraktHistoryItem(ids=TraktIds(trakt=season_id))]
+                seasons=[
+                    TraktHistoryItem(
+                        ids=TraktIds(trakt=season_id),
+                        watched_at=item.watched_at,
+                    )
+                ]
             )
             try:
                 result = await client_method(request)
+                if isinstance(result, str):
+                    BaseToolErrorMixin.handle_api_string_error(
+                        resource_type="sync_history_season",
+                        resource_id=str(season_id),
+                        error_message=result,
+                        operation=operation,
+                    )
                 _aggregate_summary(combined, result, operation)
             except Exception:
                 logger.warning(

--- a/server/sync/tools.py
+++ b/server/sync/tools.py
@@ -135,7 +135,7 @@ async def _batch_show_history_op(
             request = TraktHistoryRequest(shows=[item])
             result = await client_method(request)
             if isinstance(result, str):
-                BaseToolErrorMixin.handle_api_string_error(
+                raise BaseToolErrorMixin.handle_api_string_error(
                     resource_type="sync_history_show",
                     resource_id="unknown",
                     error_message=result,
@@ -154,12 +154,12 @@ async def _batch_show_history_op(
             request = TraktHistoryRequest(shows=[item])
             result = await client_method(request)
             if isinstance(result, str):
-                BaseToolErrorMixin.handle_api_string_error(
+                raise BaseToolErrorMixin.handle_api_string_error(
                     resource_type="sync_history_show",
                     resource_id=show_id,
                     error_message=result,
                     operation=operation,
-                )
+                ) from None
             _aggregate_summary(combined, result, operation)
             continue
 
@@ -171,7 +171,7 @@ async def _batch_show_history_op(
             request = TraktHistoryRequest(shows=[item])
             result = await client_method(request)
             if isinstance(result, str):
-                BaseToolErrorMixin.handle_api_string_error(
+                raise BaseToolErrorMixin.handle_api_string_error(
                     resource_type="sync_history_show",
                     resource_id=show_id,
                     error_message=result,
@@ -194,13 +194,15 @@ async def _batch_show_history_op(
             try:
                 result = await client_method(request)
                 if isinstance(result, str):
-                    BaseToolErrorMixin.handle_api_string_error(
+                    raise BaseToolErrorMixin.handle_api_string_error(
                         resource_type="sync_history_season",
                         resource_id=str(season_id),
                         error_message=result,
                         operation=operation,
                     )
                 _aggregate_summary(combined, result, operation)
+            except MCPError:
+                raise
             except Exception:
                 logger.warning(
                     "Failed to process season %s for show %s",

--- a/tests/models/formatters/test_sync_history_formatter.py
+++ b/tests/models/formatters/test_sync_history_formatter.py
@@ -165,7 +165,7 @@ class TestSyncHistoryFormatters:
         )
 
         assert "# History Added - Movies" in result
-        assert "Successfully added **2** movies" in result
+        assert "Successfully added **2** item" in result
 
     def test_format_history_summary_removed(self) -> None:
         """Test formatting history remove operation summary."""
@@ -179,7 +179,7 @@ class TestSyncHistoryFormatters:
         )
 
         assert "# History Removed - Movies" in result
-        assert "Successfully removed **1** movies" in result
+        assert "Successfully removed **1** item" in result
 
     def test_format_history_summary_nothing_added(self) -> None:
         """Test formatting when nothing was added."""
@@ -312,7 +312,8 @@ class TestSyncHistoryFormatters:
             summary, "added", "movies"
         )
 
-        # Should show breakdown when multiple types
+        # Should show total and breakdown when multiple types
+        assert "Successfully added **6** items" in result
         assert "### Breakdown by Type" in result
         assert "Movies: 2" in result
         assert "Shows: 1" in result

--- a/tests/models/formatters/test_sync_history_formatter.py
+++ b/tests/models/formatters/test_sync_history_formatter.py
@@ -165,7 +165,7 @@ class TestSyncHistoryFormatters:
         )
 
         assert "# History Added - Movies" in result
-        assert "Successfully added **2** item" in result
+        assert "Successfully added **2** movies" in result
 
     def test_format_history_summary_removed(self) -> None:
         """Test formatting history remove operation summary."""
@@ -179,7 +179,7 @@ class TestSyncHistoryFormatters:
         )
 
         assert "# History Removed - Movies" in result
-        assert "Successfully removed **1** item" in result
+        assert "Successfully removed **1** movie" in result
 
     def test_format_history_summary_nothing_added(self) -> None:
         """Test formatting when nothing was added."""

--- a/tests/server/sync/test_history_tools.py
+++ b/tests/server/sync/test_history_tools.py
@@ -1,0 +1,282 @@
+"""Tests for sync history helper functions in server.sync.tools."""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.append(str(Path(__file__).parent.parent.parent.parent))
+
+from models.sync.history import (
+    HistoryNotFound,
+    HistorySummary,
+    HistorySummaryCount,
+    TraktHistoryItem,
+    TraktHistoryRequest,
+)
+from models.types.ids import TraktIds
+from server.sync.tools import (
+    _aggregate_summary,  # pyright: ignore[reportPrivateUsage]
+    _batch_show_history_op,  # pyright: ignore[reportPrivateUsage]
+    _get_show_season_ids,  # pyright: ignore[reportPrivateUsage]
+)
+
+# --- _aggregate_summary tests ---
+
+
+class TestAggregateSummary:
+    """Tests for the _aggregate_summary helper."""
+
+    def test_sums_added_counts(self) -> None:
+        """Added counts from source are summed into target."""
+        target = HistorySummary(
+            added=HistorySummaryCount(movies=1, episodes=3),
+        )
+        source = HistorySummary(
+            added=HistorySummaryCount(movies=2, episodes=5),
+        )
+
+        _aggregate_summary(target, source, "added")
+
+        assert target.added is not None
+        assert target.added.movies == 3
+        assert target.added.episodes == 8
+        assert target.added.shows == 0
+        assert target.added.seasons == 0
+
+    def test_creates_target_counts_when_none(self) -> None:
+        """Target gets counts created when its operation field is None."""
+        target = HistorySummary()
+        source = HistorySummary(
+            added=HistorySummaryCount(movies=2, seasons=1),
+        )
+
+        _aggregate_summary(target, source, "added")
+
+        assert target.added is not None
+        assert target.added.movies == 2
+        assert target.added.seasons == 1
+
+    def test_noop_when_source_counts_none(self) -> None:
+        """No changes when source operation field is None."""
+        target = HistorySummary(
+            added=HistorySummaryCount(movies=5),
+        )
+        source = HistorySummary()
+
+        _aggregate_summary(target, source, "added")
+
+        assert target.added is not None
+        assert target.added.movies == 5
+
+    def test_deleted_operation(self) -> None:
+        """Works with the deleted operation field."""
+        target = HistorySummary(
+            deleted=HistorySummaryCount(episodes=10),
+        )
+        source = HistorySummary(
+            deleted=HistorySummaryCount(episodes=7),
+        )
+
+        _aggregate_summary(target, source, "deleted")
+
+        assert target.deleted is not None
+        assert target.deleted.episodes == 17
+
+    def test_extends_not_found_lists(self) -> None:
+        """Not-found items from source are appended to target."""
+        target = HistorySummary(
+            added=HistorySummaryCount(movies=1),
+            not_found=HistoryNotFound(
+                movies=[TraktHistoryItem(title="A")],
+                shows=[],
+                seasons=[],
+                episodes=[],
+            ),
+        )
+        source = HistorySummary(
+            added=HistorySummaryCount(movies=1),
+            not_found=HistoryNotFound(
+                movies=[TraktHistoryItem(title="B")],
+                shows=[],
+                seasons=[],
+                episodes=[],
+            ),
+        )
+
+        _aggregate_summary(target, source, "added")
+
+        assert len(target.not_found.movies) == 2
+        assert target.not_found.movies[0].title == "A"
+        assert target.not_found.movies[1].title == "B"
+
+
+# --- _get_show_season_ids tests ---
+
+
+class TestGetShowSeasonIds:
+    """Tests for the _get_show_season_ids helper."""
+
+    @pytest.mark.asyncio
+    async def test_excludes_specials(self) -> None:
+        """Season 0 (specials) is excluded from the result."""
+        mock_seasons = [
+            {"number": 0, "ids": {"trakt": 100}},
+            {"number": 1, "ids": {"trakt": 101}},
+            {"number": 2, "ids": {"trakt": 102}},
+            {"number": 3, "ids": {"trakt": 103}},
+        ]
+
+        with patch("server.sync.tools.ShowSeasonsClient") as mock_cls:
+            mock_cls.return_value.get_seasons = AsyncMock(return_value=mock_seasons)
+            result = await _get_show_season_ids("breaking-bad")
+
+        assert result == [101, 102, 103]
+
+    @pytest.mark.asyncio
+    async def test_empty_seasons(self) -> None:
+        """Returns empty list when show has no seasons."""
+        with patch("server.sync.tools.ShowSeasonsClient") as mock_cls:
+            mock_cls.return_value.get_seasons = AsyncMock(return_value=[])
+            result = await _get_show_season_ids("some-show")
+
+        assert result == []
+
+
+# --- _batch_show_history_op tests ---
+
+
+def _make_summary(operation: str, episodes: int = 0) -> HistorySummary:
+    """Create a simple HistorySummary with a count."""
+    counts = HistorySummaryCount(episodes=episodes)
+    summary = HistorySummary()
+    setattr(summary, operation, counts)
+    return summary
+
+
+class TestBatchShowHistoryOp:
+    """Tests for the _batch_show_history_op helper."""
+
+    @pytest.mark.asyncio
+    async def test_splits_by_season(self) -> None:
+        """Show is split into per-season requests and results aggregated."""
+        client_method = AsyncMock(
+            side_effect=[
+                _make_summary("added", episodes=10),
+                _make_summary("added", episodes=8),
+                _make_summary("added", episodes=12),
+            ]
+        )
+        show_item = TraktHistoryItem(ids=TraktIds(trakt=1390))
+
+        with patch(
+            "server.sync.tools._get_show_season_ids",
+            new_callable=AsyncMock,
+            return_value=[201, 202, 203],
+        ):
+            result = await _batch_show_history_op(client_method, [show_item], "added")
+
+        assert client_method.call_count == 3
+        assert result.added is not None
+        assert result.added.episodes == 30
+
+    @pytest.mark.asyncio
+    async def test_no_resolvable_id_sends_as_show(self) -> None:
+        """Item with no IDs is sent as a single show request."""
+        client_method = AsyncMock(return_value=_make_summary("added", episodes=5))
+        show_item = TraktHistoryItem(ids=None, title="Mystery Show")
+
+        result = await _batch_show_history_op(client_method, [show_item], "added")
+
+        client_method.assert_called_once()
+        call_request: TraktHistoryRequest = client_method.call_args[0][0]
+        assert call_request.shows is not None
+        assert call_request.shows[0].title == "Mystery Show"
+        assert result.added is not None
+        assert result.added.episodes == 5
+
+    @pytest.mark.asyncio
+    async def test_slug_fallback(self) -> None:
+        """Uses slug when trakt ID is absent."""
+        client_method = AsyncMock(return_value=_make_summary("deleted", episodes=6))
+        show_item = TraktHistoryItem(ids=TraktIds(slug="breaking-bad"))
+
+        with patch(
+            "server.sync.tools._get_show_season_ids",
+            new_callable=AsyncMock,
+            return_value=[301],
+        ) as mock_get_ids:
+            result = await _batch_show_history_op(client_method, [show_item], "deleted")
+
+        mock_get_ids.assert_called_once_with("breaking-bad")
+        assert result.deleted is not None
+        assert result.deleted.episodes == 6
+
+    @pytest.mark.asyncio
+    async def test_season_fetch_failure_falls_back(self) -> None:
+        """Falls back to single show request when season fetch fails."""
+        client_method = AsyncMock(return_value=_make_summary("added", episodes=50))
+        show_item = TraktHistoryItem(ids=TraktIds(trakt=1390))
+
+        with patch(
+            "server.sync.tools._get_show_season_ids",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("API failure"),
+        ):
+            result = await _batch_show_history_op(client_method, [show_item], "added")
+
+        client_method.assert_called_once()
+        call_request: TraktHistoryRequest = client_method.call_args[0][0]
+        assert call_request.shows is not None
+        assert result.added is not None
+        assert result.added.episodes == 50
+
+    @pytest.mark.asyncio
+    async def test_multiple_shows_aggregated(self) -> None:
+        """Multiple show items are each processed and aggregated."""
+        client_method = AsyncMock(
+            side_effect=[
+                _make_summary("added", episodes=10),
+                _make_summary("added", episodes=20),
+            ]
+        )
+        items = [
+            TraktHistoryItem(ids=TraktIds(trakt=100)),
+            TraktHistoryItem(ids=TraktIds(trakt=200)),
+        ]
+
+        with patch(
+            "server.sync.tools._get_show_season_ids",
+            new_callable=AsyncMock,
+            # Each show has 1 season
+            side_effect=[[501], [502]],
+        ):
+            result = await _batch_show_history_op(client_method, items, "added")
+
+        assert client_method.call_count == 2
+        assert result.added is not None
+        assert result.added.episodes == 30
+
+    @pytest.mark.asyncio
+    async def test_partial_season_failure_continues(self) -> None:
+        """If one season request fails, remaining seasons still proceed."""
+        client_method = AsyncMock(
+            side_effect=[
+                _make_summary("deleted", episodes=10),
+                RuntimeError("504 timeout"),
+                _make_summary("deleted", episodes=12),
+            ]
+        )
+        show_item = TraktHistoryItem(ids=TraktIds(trakt=92))
+
+        with patch(
+            "server.sync.tools._get_show_season_ids",
+            new_callable=AsyncMock,
+            return_value=[301, 302, 303],
+        ):
+            result = await _batch_show_history_op(client_method, [show_item], "deleted")
+
+        assert client_method.call_count == 3
+        assert result.deleted is not None
+        assert result.deleted.episodes == 22

--- a/utils/api/error_handler.py
+++ b/utils/api/error_handler.py
@@ -267,9 +267,8 @@ class TraktAPIErrorHandler:
         return TraktServerError(
             http_status=504,
             message=(
-                "Gateway timeout. The Trakt API took too long to respond."
-                " This can happen with large batch operations."
-                " Please try again with fewer items."
+                "Gateway timeout. The upstream service took too long to respond."
+                " Please try again later."
             ),
             endpoint=context.get("endpoint"),
             correlation_id=context.get("correlation_id"),

--- a/utils/api/error_handler.py
+++ b/utils/api/error_handler.py
@@ -105,6 +105,7 @@ class TraktAPIErrorHandler:
             500: cls.handle_server_error,
             502: cls.handle_bad_gateway,
             503: cls.handle_service_unavailable,
+            504: cls.handle_gateway_timeout,
         }
 
         return handlers.get(status_code, cls.handle_unknown_error)
@@ -256,6 +257,20 @@ class TraktAPIErrorHandler:
         return TraktServerError(
             http_status=503,
             message="Service unavailable. Please try again in 30 seconds.",
+            endpoint=context.get("endpoint"),
+            correlation_id=context.get("correlation_id"),
+        )
+
+    @classmethod
+    def handle_gateway_timeout(cls, **context: Any) -> TraktServerError:
+        """Handle 504 Gateway Timeout errors."""
+        return TraktServerError(
+            http_status=504,
+            message=(
+                "Gateway timeout. The Trakt API took too long to respond."
+                " This can happen with large batch operations."
+                " Please try again with fewer items."
+            ),
             endpoint=context.get("endpoint"),
             correlation_id=context.get("correlation_id"),
         )


### PR DESCRIPTION
fix: improve sync history batching resilience and formatter specificity

Per-season requests now catch errors individually so one failed season
doesn't abort the entire batch operation. Formatter uses specific type
names ("2 movies", "1 episode") instead of generic "items" for
single-type results. Added 13 tests for _aggregate_summary,
_get_show_season_ids, and _batch_show_history_op helpers.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed singular/plural wording and aggregated totals in sync history success messages
  * Treat empty slug/IMDb values as missing and allow history request sections to be omitted in requests
* **New Features**
  * Season-aware batching for TV show history operations with per-season requests and fallbacks
  * Explicit handling and messaging for API gateway timeout (504) responses
* **Tests**
  * Added comprehensive tests for history batching, aggregation, and related helpers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->