### PR TITLE
refactor: dedupe and prune dead code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ coverage.xml
 # MCP specific
 logs/
 *.log
+.playwright-mcp/
 
 # Distribution / packaging
 .Python

--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,3 @@ auth_token.json
 auth_token.json.tmp
 
 phase-runner-script.sh
-
-# Local working notes
-CLEANUP*.md
-cleanup_todo.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ npx @modelcontextprotocol/inspector --cli python server.py --method tools/call  
 
 ### Error Handling
 - Use `@handle_api_errors` decorator from `utils.api.errors`
-- **Always check API results before formatting** — API clients may return error strings instead of typed data. Check `isinstance(result, str)` before passing to formatters; use `BaseToolErrorMixin.handle_api_string_error()` to raise structured errors.
+- **Always check API results before formatting** — API clients may return error strings instead of typed data. Check `isinstance(result, str)` before passing to formatters; use `ToolErrors.handle_api_string_error()` to raise structured errors.
 - Authentication checks at tool/resource level
 
 ### Data Flow

--- a/client/base.py
+++ b/client/base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Any, Protocol, TypeGuard, TypeVar, overload
+from typing import TYPE_CHECKING, Any, TypeGuard, TypeVar, overload
 
 import httpx
 
@@ -22,13 +22,6 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-class PydanticModel(Protocol):
-    """Protocol for Pydantic models."""
-
-    @classmethod
-    def model_validate(cls, obj: Any) -> Any: ...
-
-
 def _is_dict_response(result: Any) -> TypeGuard[dict[str, Any]]:
     """Type guard for dict responses."""
     return isinstance(result, dict)
@@ -39,17 +32,12 @@ def _is_list(result: Any) -> TypeGuard[list[Any]]:
     return isinstance(result, list)
 
 
-def _is_list_of_dicts(result: list[Any]) -> TypeGuard[list[dict[str, Any]]]:
-    """Type guard: narrows list[Any] to list[dict[str, Any]]."""
-    return all(isinstance(item, dict) for item in result)
-
-
 def _is_list_response(result: Any) -> TypeGuard[list[dict[str, Any]]]:
     """Type guard for list responses."""
-    return _is_list(result) and _is_list_of_dicts(result)
+    return _is_list(result) and all(isinstance(item, dict) for item in result)
 
 
-def _is_pydantic_model(cls: type[object]) -> TypeGuard[type[PydanticModel]]:
+def _is_pydantic_model(cls: type[object]) -> TypeGuard[type[Any]]:
     """Type guard for Pydantic models."""
     return hasattr(cls, "model_validate") and hasattr(cls, "__annotations__")
 

--- a/client/base.py
+++ b/client/base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Any, TypeGuard, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Protocol, TypeGuard, TypeVar, overload
 
 import httpx
 
@@ -22,6 +22,13 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
+class PydanticModel(Protocol):
+    """Protocol for Pydantic models."""
+
+    @classmethod
+    def model_validate(cls, obj: Any) -> Any: ...
+
+
 def _is_dict_response(result: Any) -> TypeGuard[dict[str, Any]]:
     """Type guard for dict responses."""
     return isinstance(result, dict)
@@ -37,7 +44,7 @@ def _is_list_response(result: Any) -> TypeGuard[list[dict[str, Any]]]:
     return _is_list(result) and all(isinstance(item, dict) for item in result)
 
 
-def _is_pydantic_model(cls: type[object]) -> TypeGuard[type[Any]]:
+def _is_pydantic_model(cls: type[object]) -> TypeGuard[type[PydanticModel]]:
     """Type guard for Pydantic models."""
     return hasattr(cls, "model_validate") and hasattr(cls, "__annotations__")
 

--- a/config/mcp/tools/__init__.py
+++ b/config/mcp/tools/__init__.py
@@ -1,5 +1,7 @@
 """MCP tools organized by domain."""
 
+from typing import Final
+
 from .auth import AUTH_TOOLS
 from .checkin import CHECKIN_TOOLS
 from .comments import COMMENT_TOOLS
@@ -14,22 +16,21 @@ from .shows import SHOW_TOOLS
 from .sync import SYNC_TOOLS
 from .user import USER_TOOLS
 
-# Combine all tools for backward compatibility
-TOOL_NAMES = {
-    **SHOW_TOOLS,
-    **MOVIE_TOOLS,
-    **PEOPLE_TOOLS,
-    **AUTH_TOOLS,
-    **USER_TOOLS,
-    **CHECKIN_TOOLS,
-    **COMMENT_TOOLS,
-    **EPISODE_TOOLS,
-    **PROGRESS_TOOLS,
-    **RECOMMENDATIONS_TOOLS,
-    **SEARCH_TOOLS,
-    **SEASON_TOOLS,
-    **SYNC_TOOLS,
-}
+TOOL_NAMES: Final[frozenset[str]] = (
+    SHOW_TOOLS
+    | MOVIE_TOOLS
+    | PEOPLE_TOOLS
+    | AUTH_TOOLS
+    | USER_TOOLS
+    | CHECKIN_TOOLS
+    | COMMENT_TOOLS
+    | EPISODE_TOOLS
+    | PROGRESS_TOOLS
+    | RECOMMENDATIONS_TOOLS
+    | SEARCH_TOOLS
+    | SEASON_TOOLS
+    | SYNC_TOOLS
+)
 
 __all__ = [
     "AUTH_TOOLS",

--- a/config/mcp/tools/auth.py
+++ b/config/mcp/tools/auth.py
@@ -2,9 +2,10 @@
 
 from typing import Final
 
-# Authentication MCP Tool Names
-AUTH_TOOLS: Final[dict[str, str]] = {
-    "start_device_auth": "start_device_auth",
-    "check_auth_status": "check_auth_status",
-    "clear_auth": "clear_auth",
-}
+AUTH_TOOLS: Final[frozenset[str]] = frozenset(
+    {
+        "start_device_auth",
+        "check_auth_status",
+        "clear_auth",
+    }
+)

--- a/config/mcp/tools/checkin.py
+++ b/config/mcp/tools/checkin.py
@@ -2,7 +2,4 @@
 
 from typing import Final
 
-# Check-in MCP Tool Names
-CHECKIN_TOOLS: Final[dict[str, str]] = {
-    "checkin_to_show": "checkin_to_show",
-}
+CHECKIN_TOOLS: Final[frozenset[str]] = frozenset({"checkin_to_show"})

--- a/config/mcp/tools/comments.py
+++ b/config/mcp/tools/comments.py
@@ -2,12 +2,13 @@
 
 from typing import Final
 
-# Comments MCP Tool Names
-COMMENT_TOOLS: Final[dict[str, str]] = {
-    "fetch_movie_comments": "fetch_movie_comments",
-    "fetch_show_comments": "fetch_show_comments",
-    "fetch_season_comments": "fetch_season_comments",
-    "fetch_episode_comments": "fetch_episode_comments",
-    "fetch_comment": "fetch_comment",
-    "fetch_comment_replies": "fetch_comment_replies",
-}
+COMMENT_TOOLS: Final[frozenset[str]] = frozenset(
+    {
+        "fetch_movie_comments",
+        "fetch_show_comments",
+        "fetch_season_comments",
+        "fetch_episode_comments",
+        "fetch_comment",
+        "fetch_comment_replies",
+    }
+)

--- a/config/mcp/tools/episodes.py
+++ b/config/mcp/tools/episodes.py
@@ -2,14 +2,15 @@
 
 from typing import Final
 
-# Episode MCP Tool Names
-EPISODE_TOOLS: Final[dict[str, str]] = {
-    "fetch_episode_summary": "fetch_episode_summary",
-    "fetch_episode_translations": "fetch_episode_translations",
-    "fetch_episode_lists": "fetch_episode_lists",
-    "fetch_episode_people": "fetch_episode_people",
-    "fetch_episode_ratings": "fetch_episode_ratings",
-    "fetch_episode_stats": "fetch_episode_stats",
-    "fetch_episode_watching": "fetch_episode_watching",
-    "fetch_episode_videos": "fetch_episode_videos",
-}
+EPISODE_TOOLS: Final[frozenset[str]] = frozenset(
+    {
+        "fetch_episode_summary",
+        "fetch_episode_translations",
+        "fetch_episode_lists",
+        "fetch_episode_people",
+        "fetch_episode_ratings",
+        "fetch_episode_stats",
+        "fetch_episode_watching",
+        "fetch_episode_videos",
+    }
+)

--- a/config/mcp/tools/movies.py
+++ b/config/mcp/tools/movies.py
@@ -2,18 +2,19 @@
 
 from typing import Final
 
-# Movie MCP Tool Names
-MOVIE_TOOLS: Final[dict[str, str]] = {
-    "fetch_trending_movies": "fetch_trending_movies",
-    "fetch_popular_movies": "fetch_popular_movies",
-    "fetch_favorited_movies": "fetch_favorited_movies",
-    "fetch_played_movies": "fetch_played_movies",
-    "fetch_watched_movies": "fetch_watched_movies",
-    "fetch_anticipated_movies": "fetch_anticipated_movies",
-    "fetch_movie_ratings": "fetch_movie_ratings",
-    "fetch_movie_summary": "fetch_movie_summary",
-    "fetch_movie_videos": "fetch_movie_videos",
-    "fetch_related_movies": "fetch_related_movies",
-    "fetch_boxoffice_movies": "fetch_boxoffice_movies",
-    "fetch_movie_people": "fetch_movie_people",
-}
+MOVIE_TOOLS: Final[frozenset[str]] = frozenset(
+    {
+        "fetch_trending_movies",
+        "fetch_popular_movies",
+        "fetch_favorited_movies",
+        "fetch_played_movies",
+        "fetch_watched_movies",
+        "fetch_anticipated_movies",
+        "fetch_movie_ratings",
+        "fetch_movie_summary",
+        "fetch_movie_videos",
+        "fetch_related_movies",
+        "fetch_boxoffice_movies",
+        "fetch_movie_people",
+    }
+)

--- a/config/mcp/tools/people.py
+++ b/config/mcp/tools/people.py
@@ -2,10 +2,11 @@
 
 from typing import Final
 
-# People MCP Tool Names
-PEOPLE_TOOLS: Final[dict[str, str]] = {
-    "fetch_person_summary": "fetch_person_summary",
-    "fetch_person_movies": "fetch_person_movies",
-    "fetch_person_shows": "fetch_person_shows",
-    "fetch_person_lists": "fetch_person_lists",
-}
+PEOPLE_TOOLS: Final[frozenset[str]] = frozenset(
+    {
+        "fetch_person_summary",
+        "fetch_person_movies",
+        "fetch_person_shows",
+        "fetch_person_lists",
+    }
+)

--- a/config/mcp/tools/progress.py
+++ b/config/mcp/tools/progress.py
@@ -1,12 +1,13 @@
 """Progress-specific MCP tool name definitions."""
 
-from collections.abc import Mapping
 from typing import Final
 
-PROGRESS_TOOLS: Final[Mapping[str, str]] = {
-    "fetch_show_progress": "fetch_show_progress",
-    "fetch_playback_progress": "fetch_playback_progress",
-    "remove_playback_item": "remove_playback_item",
-}
+PROGRESS_TOOLS: Final[frozenset[str]] = frozenset(
+    {
+        "fetch_show_progress",
+        "fetch_playback_progress",
+        "remove_playback_item",
+    }
+)
 
 __all__ = ["PROGRESS_TOOLS"]

--- a/config/mcp/tools/recommendations.py
+++ b/config/mcp/tools/recommendations.py
@@ -2,12 +2,13 @@
 
 from typing import Final
 
-# Recommendation MCP Tool Names
-RECOMMENDATIONS_TOOLS: Final[dict[str, str]] = {
-    "fetch_movie_recommendations": "fetch_movie_recommendations",
-    "fetch_show_recommendations": "fetch_show_recommendations",
-    "hide_movie_recommendation": "hide_movie_recommendation",
-    "hide_show_recommendation": "hide_show_recommendation",
-    "unhide_movie_recommendation": "unhide_movie_recommendation",
-    "unhide_show_recommendation": "unhide_show_recommendation",
-}
+RECOMMENDATIONS_TOOLS: Final[frozenset[str]] = frozenset(
+    {
+        "fetch_movie_recommendations",
+        "fetch_show_recommendations",
+        "hide_movie_recommendation",
+        "hide_show_recommendation",
+        "unhide_movie_recommendation",
+        "unhide_show_recommendation",
+    }
+)

--- a/config/mcp/tools/search.py
+++ b/config/mcp/tools/search.py
@@ -2,8 +2,4 @@
 
 from typing import Final
 
-# Search MCP Tool Names
-SEARCH_TOOLS: Final[dict[str, str]] = {
-    "search_shows": "search_shows",
-    "search_movies": "search_movies",
-}
+SEARCH_TOOLS: Final[frozenset[str]] = frozenset({"search_shows", "search_movies"})

--- a/config/mcp/tools/seasons.py
+++ b/config/mcp/tools/seasons.py
@@ -2,15 +2,16 @@
 
 from typing import Final
 
-# Season MCP Tool Names
-SEASON_TOOLS: Final[dict[str, str]] = {
-    "fetch_season_info": "fetch_season_info",
-    "fetch_season_episodes": "fetch_season_episodes",
-    "fetch_season_ratings": "fetch_season_ratings",
-    "fetch_season_stats": "fetch_season_stats",
-    "fetch_season_people": "fetch_season_people",
-    "fetch_season_videos": "fetch_season_videos",
-    "fetch_season_watching": "fetch_season_watching",
-    "fetch_season_translations": "fetch_season_translations",
-    "fetch_season_lists": "fetch_season_lists",
-}
+SEASON_TOOLS: Final[frozenset[str]] = frozenset(
+    {
+        "fetch_season_info",
+        "fetch_season_episodes",
+        "fetch_season_ratings",
+        "fetch_season_stats",
+        "fetch_season_people",
+        "fetch_season_videos",
+        "fetch_season_watching",
+        "fetch_season_translations",
+        "fetch_season_lists",
+    }
+)

--- a/config/mcp/tools/shows.py
+++ b/config/mcp/tools/shows.py
@@ -2,18 +2,19 @@
 
 from typing import Final
 
-# Show MCP Tool Names
-SHOW_TOOLS: Final[dict[str, str]] = {
-    "fetch_trending_shows": "fetch_trending_shows",
-    "fetch_popular_shows": "fetch_popular_shows",
-    "fetch_favorited_shows": "fetch_favorited_shows",
-    "fetch_played_shows": "fetch_played_shows",
-    "fetch_watched_shows": "fetch_watched_shows",
-    "fetch_anticipated_shows": "fetch_anticipated_shows",
-    "fetch_show_ratings": "fetch_show_ratings",
-    "fetch_show_summary": "fetch_show_summary",
-    "fetch_show_videos": "fetch_show_videos",
-    "fetch_related_shows": "fetch_related_shows",
-    "fetch_show_seasons": "fetch_show_seasons",
-    "fetch_show_people": "fetch_show_people",
-}
+SHOW_TOOLS: Final[frozenset[str]] = frozenset(
+    {
+        "fetch_trending_shows",
+        "fetch_popular_shows",
+        "fetch_favorited_shows",
+        "fetch_played_shows",
+        "fetch_watched_shows",
+        "fetch_anticipated_shows",
+        "fetch_show_ratings",
+        "fetch_show_summary",
+        "fetch_show_videos",
+        "fetch_related_shows",
+        "fetch_show_seasons",
+        "fetch_show_people",
+    }
+)

--- a/config/mcp/tools/sync.py
+++ b/config/mcp/tools/sync.py
@@ -1,19 +1,19 @@
-"""Sync-specific MCP tool name definitions."""
+"""Sync-specific MCP tool name definitions (user personal data requiring OAuth)."""
 
-from collections.abc import Mapping
 from typing import Final
 
-# Sync MCP Tool Names (for user personal data requiring OAuth)
-SYNC_TOOLS: Final[Mapping[str, str]] = {
-    "fetch_user_ratings": "fetch_user_ratings",
-    "add_user_ratings": "add_user_ratings",
-    "remove_user_ratings": "remove_user_ratings",
-    "fetch_user_watchlist": "fetch_user_watchlist",
-    "add_user_watchlist": "add_user_watchlist",
-    "remove_user_watchlist": "remove_user_watchlist",
-    "fetch_history": "fetch_history",
-    "add_to_history": "add_to_history",
-    "remove_from_history": "remove_from_history",
-}
+SYNC_TOOLS: Final[frozenset[str]] = frozenset(
+    {
+        "fetch_user_ratings",
+        "add_user_ratings",
+        "remove_user_ratings",
+        "fetch_user_watchlist",
+        "add_user_watchlist",
+        "remove_user_watchlist",
+        "fetch_history",
+        "add_to_history",
+        "remove_from_history",
+    }
+)
 
 __all__ = ["SYNC_TOOLS"]

--- a/config/mcp/tools/user.py
+++ b/config/mcp/tools/user.py
@@ -2,8 +2,9 @@
 
 from typing import Final
 
-# User MCP Tool Names
-USER_TOOLS: Final[dict[str, str]] = {
-    "fetch_user_watched_shows": "fetch_user_watched_shows",
-    "fetch_user_watched_movies": "fetch_user_watched_movies",
-}
+USER_TOOLS: Final[frozenset[str]] = frozenset(
+    {
+        "fetch_user_watched_shows",
+        "fetch_user_watched_movies",
+    }
+)

--- a/models/formatters/episodes.py
+++ b/models/formatters/episodes.py
@@ -2,11 +2,11 @@
 
 from models.formatters.utils import (
     MAX_OVERVIEW_LENGTH,
+    format_cast_section,
     format_list_items,
     format_rating_distribution,
 )
 from models.types import (
-    CastMember,
     CrewMember,
     EpisodeResponse,
     ListItemResponse,
@@ -156,30 +156,6 @@ class EpisodeFormatters:
         return "\n".join(lines)
 
     @staticmethod
-    def _format_cast_section(members: list[CastMember], heading: str) -> str:
-        """Format a cast or guest stars section.
-
-        Args:
-            members: List of cast member data
-            heading: Section heading (e.g., "Cast", "Guest Stars")
-
-        Returns:
-            Formatted markdown section, empty string if no members
-        """
-        if not members:
-            return ""
-
-        lines: list[str] = [f"## {heading}", ""]
-        for member in members:
-            person = member.get("person", {})
-            name = person.get("name", "Unknown")
-            characters = member.get("characters", [])
-            char_str = ", ".join(characters) if characters else "Unknown Role"
-            lines.append(f"- **{name}** as {char_str}")
-        lines.append("")
-        return "\n".join(lines)
-
-    @staticmethod
     def format_episode_people(
         people: PeopleResponse, show_title: str, season: int, episode: int
     ) -> str:
@@ -215,12 +191,10 @@ class EpisodeFormatters:
             "",
         ]
 
-        cast_section = EpisodeFormatters._format_cast_section(cast, "Cast")
+        cast_section = format_cast_section(cast, "Cast")
         if cast_section:
             lines.append(cast_section)
-        guest_section = EpisodeFormatters._format_cast_section(
-            guest_stars, "Guest Stars"
-        )
+        guest_section = format_cast_section(guest_stars, "Guest Stars")
         if guest_section:
             lines.append(guest_section)
         if crew:

--- a/models/formatters/episodes.py
+++ b/models/formatters/episodes.py
@@ -3,11 +3,11 @@
 from models.formatters.utils import (
     MAX_OVERVIEW_LENGTH,
     format_cast_section,
+    format_crew_section,
     format_list_items,
     format_rating_distribution,
 )
 from models.types import (
-    CrewMember,
     EpisodeResponse,
     ListItemResponse,
     PeopleResponse,
@@ -178,7 +178,7 @@ class EpisodeFormatters:
 
         cast = people.get("cast", [])
         guest_stars = people.get("guest_stars", [])
-        crew: dict[str, list[CrewMember]] = people.get("crew", {})
+        crew = people.get("crew", {})
 
         if not cast and not guest_stars and not crew:
             return (
@@ -197,19 +197,9 @@ class EpisodeFormatters:
         guest_section = format_cast_section(guest_stars, "Guest Stars")
         if guest_section:
             lines.append(guest_section)
-        if crew:
-            lines.append("## Crew")
-            lines.append("")
-            for department, members in sorted(crew.items()):
-                lines.append(f"### {department.title()}")
-                lines.append("")
-                for member in members:
-                    person = member.get("person", {})
-                    name = person.get("name", "Unknown")
-                    jobs = member.get("jobs", [])
-                    jobs_str = ", ".join(jobs) if jobs else "Unknown"
-                    lines.append(f"- **{name}** - {jobs_str}")
-                lines.append("")
+        crew_section = format_crew_section(crew)
+        if crew_section:
+            lines.append(crew_section)
 
         return "\n".join(lines)
 

--- a/models/formatters/recommendations.py
+++ b/models/formatters/recommendations.py
@@ -1,29 +1,18 @@
 """Formatters for recommendation data."""
 
-from typing import Protocol
-
 from models.recommendations.recommendation import (
-    FavoritedByEntry,
     TraktRecommendedMovie,
     TraktRecommendedShow,
 )
-from models.types.ids import TraktIds
-
-
-class _RecommendationItem(Protocol):
-    """Protocol for recommendation items with shared attributes."""
-
-    title: str
-    year: int | None
-    ids: TraktIds
-    favorited_by: list[FavoritedByEntry]
 
 
 class RecommendationFormatters:
     """Helper class for formatting recommendation data for MCP responses."""
 
     @staticmethod
-    def _format_recommendation_item(item: _RecommendationItem) -> str:
+    def _format_recommendation_item(
+        item: TraktRecommendedMovie | TraktRecommendedShow,
+    ) -> str:
         """Format a single recommendation item.
 
         Args:

--- a/models/formatters/seasons.py
+++ b/models/formatters/seasons.py
@@ -2,11 +2,11 @@
 
 from models.formatters.utils import (
     format_cast_section,
+    format_crew_section,
     format_list_items,
     format_rating_distribution,
 )
 from models.types import (
-    CrewMember,
     EpisodeResponse,
     ListItemResponse,
     PeopleResponse,
@@ -207,26 +207,11 @@ class SeasonFormatters:
         if guest_section:
             lines.append(guest_section)
 
-        crew: dict[str, list[CrewMember]] = people.get("crew", {})
-        if crew:
-            lines.append("## Crew")
-            lines.append("")
-            for department, members in sorted(crew.items()):
-                lines.append(f"### {department.title()}")
-                lines.append("")
-                for member in members:
-                    person = member.get("person", {})
-                    name = person.get("name", "Unknown")
-                    jobs = member.get("jobs", [])
-                    jobs_str = ", ".join(jobs) if jobs else "Unknown"
-                    episode_count = member.get("episode_count")
-                    count_str = (
-                        f" ({episode_count} episodes)"
-                        if episode_count is not None
-                        else ""
-                    )
-                    lines.append(f"- **{name}** - {jobs_str}{count_str}")
-                lines.append("")
+        crew_section = format_crew_section(
+            people.get("crew", {}), include_episode_count=True
+        )
+        if crew_section:
+            lines.append(crew_section)
 
         return "\n".join(lines)
 

--- a/models/formatters/seasons.py
+++ b/models/formatters/seasons.py
@@ -1,11 +1,11 @@
 """Season formatting methods for the Trakt MCP server."""
 
 from models.formatters.utils import (
+    format_cast_section,
     format_list_items,
     format_rating_distribution,
 )
 from models.types import (
-    CastMember,
     CrewMember,
     EpisodeResponse,
     ListItemResponse,
@@ -175,34 +175,6 @@ class SeasonFormatters:
         return "\n".join(lines)
 
     @staticmethod
-    def _format_cast_section(members: list[CastMember], heading: str) -> str:
-        """Format a cast or guest stars section.
-
-        Args:
-            members: List of cast member data
-            heading: Section heading (e.g., "Cast", "Guest Stars")
-
-        Returns:
-            Formatted markdown section, empty string if no members
-        """
-        if not members:
-            return ""
-
-        lines: list[str] = [f"## {heading}", ""]
-        for member in members:
-            person = member.get("person", {})
-            name = person.get("name", "Unknown")
-            characters = member.get("characters", [])
-            char_str = ", ".join(characters) if characters else "Unknown Role"
-            episode_count = member.get("episode_count")
-            count_str = (
-                f" ({episode_count} episodes)" if episode_count is not None else ""
-            )
-            lines.append(f"- **{name}** as {char_str}{count_str}")
-        lines.append("")
-        return "\n".join(lines)
-
-    @staticmethod
     def format_season_people(
         people: PeopleResponse, show_title: str, season: int
     ) -> str:
@@ -224,13 +196,13 @@ class SeasonFormatters:
 
         lines: list[str] = [f"# People for {show_title} - Season {season}", ""]
 
-        cast_section = SeasonFormatters._format_cast_section(
-            people.get("cast", []), "Cast"
+        cast_section = format_cast_section(
+            people.get("cast", []), "Cast", include_episode_count=True
         )
         if cast_section:
             lines.append(cast_section)
-        guest_section = SeasonFormatters._format_cast_section(
-            people.get("guest_stars", []), "Guest Stars"
+        guest_section = format_cast_section(
+            people.get("guest_stars", []), "Guest Stars", include_episode_count=True
         )
         if guest_section:
             lines.append(guest_section)

--- a/models/formatters/shows.py
+++ b/models/formatters/shows.py
@@ -12,6 +12,7 @@ from models.formatters.utils import (
 from models.types import (
     AnticipatedShowWrapper,
     CastMember,
+    CrewMember,
     FavoritedShowWrapper,
     PeopleResponse,
     PlayedShowWrapper,
@@ -301,7 +302,7 @@ class ShowFormatters:
 
         cast: list[CastMember] = people.get("cast", [])
         guest_stars: list[CastMember] = people.get("guest_stars", [])
-        crew = people.get("crew", {})
+        crew: dict[str, list[CrewMember]] = people.get("crew", {})
 
         if not cast and not guest_stars and not crew:
             return f"# People for {show_title}\n\nNo people data available."

--- a/models/formatters/shows.py
+++ b/models/formatters/shows.py
@@ -2,6 +2,7 @@
 
 from models.formatters.utils import (
     MAX_OVERVIEW_LENGTH,
+    format_cast_section,
     format_media_list,
     format_pagination_header,
     format_rating_distribution,
@@ -293,26 +294,6 @@ class ShowFormatters:
         return "\n".join(lines)
 
     @staticmethod
-    def _format_cast_section(members: list[CastMember], heading: str) -> str:
-        """Format a cast or guest stars section."""
-        if not members:
-            return ""
-
-        lines: list[str] = [f"## {heading}", ""]
-        for member in members:
-            person = member.get("person", {})
-            name = person.get("name", "Unknown")
-            characters = member.get("characters", [])
-            char_str = ", ".join(characters) if characters else "Unknown Role"
-            episode_count = member.get("episode_count")
-            count_str = (
-                f" ({episode_count} episodes)" if episode_count is not None else ""
-            )
-            lines.append(f"- **{name}** as {char_str}{count_str}")
-        lines.append("")
-        return "\n".join(lines)
-
-    @staticmethod
     def format_show_people(people: PeopleResponse, show_title: str) -> str:
         """Format show cast and crew data."""
         if not people:
@@ -327,10 +308,12 @@ class ShowFormatters:
 
         lines: list[str] = [f"# People for {show_title}", ""]
 
-        cast_section = ShowFormatters._format_cast_section(cast, "Cast")
+        cast_section = format_cast_section(cast, "Cast", include_episode_count=True)
         if cast_section:
             lines.append(cast_section)
-        guest_section = ShowFormatters._format_cast_section(guest_stars, "Guest Stars")
+        guest_section = format_cast_section(
+            guest_stars, "Guest Stars", include_episode_count=True
+        )
         if guest_section:
             lines.append(guest_section)
         if crew:

--- a/models/formatters/shows.py
+++ b/models/formatters/shows.py
@@ -3,6 +3,7 @@
 from models.formatters.utils import (
     MAX_OVERVIEW_LENGTH,
     format_cast_section,
+    format_crew_section,
     format_media_list,
     format_pagination_header,
     format_rating_distribution,
@@ -11,7 +12,6 @@ from models.formatters.utils import (
 from models.types import (
     AnticipatedShowWrapper,
     CastMember,
-    CrewMember,
     FavoritedShowWrapper,
     PeopleResponse,
     PlayedShowWrapper,
@@ -301,7 +301,7 @@ class ShowFormatters:
 
         cast: list[CastMember] = people.get("cast", [])
         guest_stars: list[CastMember] = people.get("guest_stars", [])
-        crew: dict[str, list[CrewMember]] = people.get("crew", {})
+        crew = people.get("crew", {})
 
         if not cast and not guest_stars and not crew:
             return f"# People for {show_title}\n\nNo people data available."
@@ -316,24 +316,8 @@ class ShowFormatters:
         )
         if guest_section:
             lines.append(guest_section)
-        if crew:
-            lines.append("## Crew")
-            lines.append("")
-            for department, members in sorted(crew.items()):
-                lines.append(f"### {department.title()}")
-                lines.append("")
-                for member in members:
-                    person = member.get("person", {})
-                    name = person.get("name", "Unknown")
-                    jobs = member.get("jobs", [])
-                    jobs_str = ", ".join(jobs) if jobs else "Unknown"
-                    episode_count = member.get("episode_count")
-                    count_str = (
-                        f" ({episode_count} episodes)"
-                        if episode_count is not None
-                        else ""
-                    )
-                    lines.append(f"- **{name}** - {jobs_str}{count_str}")
-                lines.append("")
+        crew_section = format_crew_section(crew, include_episode_count=True)
+        if crew_section:
+            lines.append(crew_section)
 
         return "\n".join(lines)

--- a/models/formatters/utils.py
+++ b/models/formatters/utils.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any, Final, TypeVar
 
-from models.types.api_responses import CastMember, ListItemResponse
+from models.types.api_responses import CastMember, CrewMember, ListItemResponse
 from models.types.pagination import PaginatedResponse
 from utils.formatting import DISPLAY_DATETIME_FORMAT, format_iso_timestamp
 
@@ -164,6 +164,45 @@ def format_cast_section(
                 count_str = f" ({episode_count} episodes)"
         lines.append(f"- **{name}** as {char_str}{count_str}")
     lines.append("")
+    return "\n".join(lines)
+
+
+def format_crew_section(
+    crew: dict[str, list[CrewMember]],
+    *,
+    include_episode_count: bool = False,
+    heading: str = "Crew",
+) -> str:
+    """Format a crew section grouped by department as markdown.
+
+    Args:
+        crew: Mapping of department name → crew member list (Trakt API shape).
+        include_episode_count: Append ``(N episodes)`` when the member carries
+            an ``episode_count`` (shows and seasons do; individual episodes do not).
+        heading: Section heading (default ``"Crew"``).
+
+    Returns:
+        Markdown section, or an empty string if ``crew`` is empty.
+    """
+    if not crew:
+        return ""
+
+    lines: list[str] = [f"## {heading}", ""]
+    for department, members in sorted(crew.items()):
+        lines.append(f"### {department.title()}")
+        lines.append("")
+        for member in members:
+            person = member.get("person", {})
+            name = person.get("name", "Unknown")
+            jobs = member.get("jobs", [])
+            jobs_str = ", ".join(jobs) if jobs else "Unknown"
+            count_str = ""
+            if include_episode_count:
+                episode_count = member.get("episode_count")
+                if episode_count is not None:
+                    count_str = f" ({episode_count} episodes)"
+            lines.append(f"- **{name}** - {jobs_str}{count_str}")
+        lines.append("")
     return "\n".join(lines)
 
 

--- a/models/formatters/utils.py
+++ b/models/formatters/utils.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable, Mapping, Sequence
 from typing import Any, Final, TypeVar
 
-from models.types.api_responses import ListItemResponse
+from models.types.api_responses import CastMember, ListItemResponse
 from models.types.pagination import PaginatedResponse
 from utils.formatting import DISPLAY_DATETIME_FORMAT, format_iso_timestamp
 
@@ -128,6 +128,42 @@ def format_list_items(
                 description = description[: MAX_OVERVIEW_LENGTH - 3] + "..."
             lines.append(f"  {description}")
 
+    return "\n".join(lines)
+
+
+def format_cast_section(
+    members: list[CastMember],
+    heading: str,
+    *,
+    include_episode_count: bool = False,
+) -> str:
+    """Format a cast or guest stars section as markdown.
+
+    Args:
+        members: Cast member data from the API.
+        heading: Section heading (e.g. "Cast", "Guest Stars").
+        include_episode_count: Append ``(N episodes)`` when the member carries
+            an ``episode_count`` (shows and seasons do; individual episodes do not).
+
+    Returns:
+        Markdown section, or an empty string if ``members`` is empty.
+    """
+    if not members:
+        return ""
+
+    lines: list[str] = [f"## {heading}", ""]
+    for member in members:
+        person = member.get("person", {})
+        name = person.get("name", "Unknown")
+        characters = member.get("characters", [])
+        char_str = ", ".join(characters) if characters else "Unknown Role"
+        count_str = ""
+        if include_episode_count:
+            episode_count = member.get("episode_count")
+            if episode_count is not None:
+                count_str = f" ({episode_count} episodes)"
+        lines.append(f"- **{name}** as {char_str}{count_str}")
+    lines.append("")
     return "\n".join(lines)
 
 

--- a/server/auth/tools.py
+++ b/server/auth/tools.py
@@ -11,7 +11,7 @@ from client.auth import AuthClient
 from client.pool import get_client
 from config.auth import AUTH_VERIFICATION_URL
 from models.formatters.auth import AuthFormatters
-from server.base.error_mixin import ToolErrors
+from server.base import ToolErrors
 from utils.api.error_types import AuthorizationPendingError
 from utils.api.errors import InternalError
 

--- a/server/auth/tools.py
+++ b/server/auth/tools.py
@@ -10,7 +10,6 @@ from mcp.server.fastmcp import FastMCP
 from client.auth import AuthClient
 from client.pool import get_client
 from config.auth import AUTH_VERIFICATION_URL
-from config.mcp.tools import TOOL_NAMES
 from models.formatters.auth import AuthFormatters
 from server.base.error_mixin import BaseToolErrorMixin
 from utils.api.error_types import AuthorizationPendingError
@@ -210,21 +209,21 @@ def register_auth_tools(mcp: FastMCP) -> tuple[Any, Any, Any]:
     """
 
     @mcp.tool(
-        name=TOOL_NAMES["start_device_auth"],
+        name="start_device_auth",
         description="Start the device authentication flow with Trakt TV",
     )
     async def start_device_auth_tool() -> str:
         return await start_device_auth()
 
     @mcp.tool(
-        name=TOOL_NAMES["check_auth_status"],
+        name="check_auth_status",
         description="Check the status of an ongoing device authentication flow",
     )
     async def check_auth_status_tool() -> str:
         return await check_auth_status()
 
     @mcp.tool(
-        name=TOOL_NAMES["clear_auth"],
+        name="clear_auth",
         description="Clear the authentication token and log out of Trakt",
     )
     async def clear_auth_tool() -> str:

--- a/server/auth/tools.py
+++ b/server/auth/tools.py
@@ -11,7 +11,7 @@ from client.auth import AuthClient
 from client.pool import get_client
 from config.auth import AUTH_VERIFICATION_URL
 from models.formatters.auth import AuthFormatters
-from server.base.error_mixin import BaseToolErrorMixin
+from server.base.error_mixin import ToolErrors
 from utils.api.error_types import AuthorizationPendingError
 from utils.api.errors import InternalError
 
@@ -51,7 +51,7 @@ async def start_device_auth() -> str:
 
     # Handle transitional case where API returns error strings
     if isinstance(device_code_response, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="device_code",
             resource_id="auth_flow",
             error_message=device_code_response,

--- a/server/base/__init__.py
+++ b/server/base/__init__.py
@@ -1,6 +1,6 @@
 """Base classes and mixins for MCP server components."""
 
-from .error_mixin import BaseToolErrorMixin
+from .error_mixin import ToolErrors
 from .identifier_mixin import IdentifierValidatorMixin
 from .limit_page_mixin import LimitPageValidatorMixin
 from .params import (
@@ -15,7 +15,6 @@ from .params import (
 )
 
 __all__ = [
-    "BaseToolErrorMixin",
     "CommentIdParam",
     "EpisodeIdParam",
     "IdentifierValidatorMixin",
@@ -26,4 +25,5 @@ __all__ = [
     "PersonIdParam",
     "SeasonIdParam",
     "ShowIdParam",
+    "ToolErrors",
 ]

--- a/server/base/error_mixin.py
+++ b/server/base/error_mixin.py
@@ -175,7 +175,7 @@ def sanitize_kwargs(kwargs: dict[str, Any]) -> str:
     return str(sanitized)
 
 
-class BaseToolErrorMixin:
+class ToolErrors:
     """Mixin providing standardized error handling for MCP tools.
 
     This mixin ensures all tools follow consistent error handling patterns:

--- a/server/base/error_mixin.py
+++ b/server/base/error_mixin.py
@@ -1,4 +1,4 @@
-"""Base error handling mixin for MCP tools."""
+"""Standardized error handling helpers for MCP tools."""
 
 from collections.abc import Awaitable, Callable
 from functools import wraps
@@ -176,13 +176,16 @@ def sanitize_kwargs(kwargs: dict[str, Any]) -> str:
 
 
 class ToolErrors:
-    """Mixin providing standardized error handling for MCP tools.
+    """Static namespace of standardized error-handling helpers for MCP tools.
 
-    This mixin ensures all tools follow consistent error handling patterns:
-    1. Never return string errors - always raise structured MCP errors
-    2. Provide rich context for debugging
-    3. Handle authentication requirements consistently
-    4. Convert unexpected errors to proper MCP errors
+    Holds no instance state and is not meant to be inherited; every member is a
+    ``@staticmethod`` or ``@classmethod`` and call sites use ``ToolErrors.foo(...)``
+    directly. Responsibilities:
+
+    1. Raise structured MCP errors instead of returning string errors
+    2. Attach request context for debugging
+    3. Handle authentication-required failures consistently
+    4. Convert unexpected exceptions into proper MCP errors
     """
 
     @staticmethod

--- a/server/checkin/tools.py
+++ b/server/checkin/tools.py
@@ -13,7 +13,6 @@ from config.mcp.descriptions import (
     SEASON_DESCRIPTION,
     SHOW_ID_DESCRIPTION,
 )
-from config.mcp.tools import TOOL_NAMES
 from models.formatters.checkin import CheckinFormatters
 from server.base import BaseToolErrorMixin
 
@@ -122,7 +121,7 @@ def register_checkin_tools(mcp: FastMCP) -> Any:
     """
 
     @mcp.tool(
-        name=TOOL_NAMES["checkin_to_show"],
+        name="checkin_to_show",
         description="Check in to a TV show episode you're currently watching on Trakt",
     )
     async def checkin_to_show_tool(

--- a/server/checkin/tools.py
+++ b/server/checkin/tools.py
@@ -14,7 +14,7 @@ from config.mcp.descriptions import (
     SHOW_ID_DESCRIPTION,
 )
 from models.formatters.checkin import CheckinFormatters
-from server.base import BaseToolErrorMixin
+from server.base import ToolErrors
 
 logger = logging.getLogger("trakt_mcp")
 
@@ -60,7 +60,7 @@ async def checkin_to_show(
 
     # Check authentication (attempts token refresh if expired)
     if not await client.ensure_authenticated():
-        raise BaseToolErrorMixin.handle_authentication_required(
+        raise ToolErrors.handle_authentication_required(
             action="check in to a show episode",
             show_id=show_id,
             show_title=show_title,
@@ -69,7 +69,7 @@ async def checkin_to_show(
         )
 
     # Validate parameters
-    BaseToolErrorMixin.validate_either_or_params(
+    ToolErrors.validate_either_or_params(
         param_sets=[("show_id",), ("show_title",)],
         show_id=show_id,
         show_title=show_title,
@@ -91,7 +91,7 @@ async def checkin_to_show(
 
         # Handle transitional case where API returns error strings
         if isinstance(response, str):
-            raise BaseToolErrorMixin.handle_api_string_error(
+            raise ToolErrors.handle_api_string_error(
                 resource_type="checkin",
                 resource_id=show_id or show_title or "unknown",
                 error_message=response,
@@ -102,7 +102,7 @@ async def checkin_to_show(
         return CheckinFormatters.format_checkin_response(response)
     except Exception as e:
         # Convert any unexpected errors to structured MCP errors
-        raise BaseToolErrorMixin.handle_unexpected_error(
+        raise ToolErrors.handle_unexpected_error(
             operation="check in to show episode",
             error=e,
             show_id=show_id,

--- a/server/comments/tools.py
+++ b/server/comments/tools.py
@@ -26,7 +26,6 @@ from config.mcp.descriptions import (
     SHOW_ID_DESCRIPTION,
     SHOW_SPOILERS_DESCRIPTION,
 )
-from config.mcp.tools import TOOL_NAMES
 from models.formatters.comments import CommentsFormatters
 from models.types import CommentResponse
 from models.types.pagination import PaginatedResponse
@@ -591,7 +590,7 @@ def register_comment_tools(
     """
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_movie_comments"],
+        name="fetch_movie_comments",
         description=(
             "Fetch comments for a specific movie from Trakt. "
             "Supports optional pagination with 'page' parameter and "
@@ -619,7 +618,7 @@ def register_comment_tools(
         )
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_show_comments"],
+        name="fetch_show_comments",
         description=(
             "Fetch comments for a specific TV show from Trakt. "
             "Supports optional pagination with 'page' parameter and "
@@ -647,7 +646,7 @@ def register_comment_tools(
         )
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_season_comments"],
+        name="fetch_season_comments",
         description=(
             "Fetch comments for a specific TV show season from Trakt. "
             "Supports optional pagination with 'page' parameter and "
@@ -676,7 +675,7 @@ def register_comment_tools(
         )
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_episode_comments"],
+        name="fetch_episode_comments",
         description=(
             "Fetch comments for a specific TV show episode from Trakt. "
             "Supports optional pagination with 'page' parameter and "
@@ -706,7 +705,7 @@ def register_comment_tools(
         )
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_comment"],
+        name="fetch_comment",
         description="Fetch a specific comment from Trakt",
     )
     async def fetch_comment_tool(
@@ -720,7 +719,7 @@ def register_comment_tools(
         return await fetch_comment(comment_id, show_spoilers)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_comment_replies"],
+        name="fetch_comment_replies",
         description=(
             "Fetch replies for a specific comment from Trakt. "
             "Supports optional pagination with 'page' parameter and "

--- a/server/comments/tools.py
+++ b/server/comments/tools.py
@@ -30,11 +30,11 @@ from models.formatters.comments import CommentsFormatters
 from models.types import CommentResponse
 from models.types.pagination import PaginatedResponse
 from server.base import (
-    BaseToolErrorMixin,
     CommentIdParam,
     LimitPageValidatorMixin,
     MovieIdParam,
     ShowIdParam,
+    ToolErrors,
 )
 from utils.api.errors import handle_api_errors_func
 from utils.api.request_context import set_tool_context
@@ -115,14 +115,14 @@ class RepliesListOptionsParam(LimitPageValidatorMixin):
 
 
 def _handle_validation_error(e: ValidationError, context: str) -> NoReturn:
-    """Handle validation errors with consistent formatting via BaseToolErrorMixin.
+    """Handle validation errors with consistent formatting via ToolErrors.
 
     Args:
         e: The ValidationError to handle
         context: Context string for the error message
 
     Raises:
-        BaseToolErrorMixin error: Formatted validation error via mixin
+        ToolErrors error: Formatted validation error via mixin
     """
     validation_errors: list[ValidationErrorDetail] = [
         ValidationErrorDetail(
@@ -134,7 +134,7 @@ def _handle_validation_error(e: ValidationError, context: str) -> NoReturn:
         for error in e.errors()
     ]
 
-    raise BaseToolErrorMixin.handle_validation_error(
+    raise ToolErrors.handle_validation_error(
         f"Invalid parameters for {context}",
         validation_errors=validation_errors,
         operation=f"{context.replace(' ', '_')}_validation",
@@ -153,10 +153,10 @@ def _ensure_not_error_string(
         operation: Operation being performed for error context
 
     Raises:
-        BaseToolErrorMixin error: If value is an error string
+        ToolErrors error: If value is an error string
     """
     if isinstance(value, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type=resource_type,
             resource_id=resource_id,
             error_message=value,
@@ -187,7 +187,7 @@ async def _fetch_and_format_comments(
         Formatted comments as markdown string
 
     Raises:
-        BaseToolErrorMixin error: If API response is an error string
+        ToolErrors error: If API response is an error string
     """
     data = await fetch_fn()
     _ensure_not_error_string(
@@ -218,11 +218,11 @@ async def _fetch_and_format_comment(
         Formatted comment as markdown string
 
     Raises:
-        BaseToolErrorMixin error: If API response is an error string
+        ToolErrors error: If API response is an error string
     """
     data = await fetch_fn()
     if isinstance(data, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type=resource_type,
             resource_id=resource_id,
             error_message=data,
@@ -544,7 +544,7 @@ async def fetch_comment_replies(
     # Fetch comment data
     comment = await client.get_comment(comment_id)
     if isinstance(comment, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="comment",
             resource_id=comment_id,
             error_message=comment,

--- a/server/episodes/tools.py
+++ b/server/episodes/tools.py
@@ -30,7 +30,7 @@ from config.mcp.descriptions import (
 from models.formatters.episodes import EpisodeFormatters
 from models.formatters.videos import VideoFormatters
 from models.types.language import validate_language
-from server.base import BaseToolErrorMixin, EpisodeIdParam
+from server.base import EpisodeIdParam, ToolErrors
 from utils.api.errors import handle_api_errors_func
 from utils.api.request_context import set_tool_context
 
@@ -99,7 +99,7 @@ async def fetch_episode_summary(show_id: str, season: int, episode: int) -> str:
     )
 
     if isinstance(episode_data, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="episode",
             resource_id=f"{params.show_id}/S{params.season:02d}E{params.episode:02d}",
             error_message=episode_data,
@@ -133,7 +133,7 @@ async def fetch_episode_ratings(show_id: str, season: int, episode: int) -> str:
     )
 
     if isinstance(ratings, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="episode_ratings",
             resource_id=f"{params.show_id}/S{params.season:02d}E{params.episode:02d}",
             error_message=ratings,
@@ -168,7 +168,7 @@ async def fetch_episode_stats(show_id: str, season: int, episode: int) -> str:
     )
 
     if isinstance(stats, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="episode_stats",
             resource_id=f"{params.show_id}/S{params.season:02d}E{params.episode:02d}",
             error_message=stats,
@@ -203,7 +203,7 @@ async def fetch_episode_people(show_id: str, season: int, episode: int) -> str:
     )
 
     if isinstance(people, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="episode_people",
             resource_id=f"{params.show_id}/S{params.season:02d}E{params.episode:02d}",
             error_message=people,
@@ -241,7 +241,7 @@ async def fetch_episode_videos(
     )
 
     if isinstance(videos, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="episode_videos",
             resource_id=f"{params.show_id}/S{params.season:02d}E{params.episode:02d}",
             error_message=videos,
@@ -278,7 +278,7 @@ async def fetch_episode_watching(show_id: str, season: int, episode: int) -> str
     )
 
     if isinstance(users, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="episode_watching",
             resource_id=f"{params.show_id}/S{params.season:02d}E{params.episode:02d}",
             error_message=users,
@@ -312,7 +312,7 @@ async def fetch_episode_translations(
     try:
         language = validate_language(language)
     except ValueError as err:
-        raise BaseToolErrorMixin.handle_validation_error(
+        raise ToolErrors.handle_validation_error(
             INVALID_LANGUAGE_MSG,
             parameter="language",
             provided_value=language,
@@ -327,7 +327,7 @@ async def fetch_episode_translations(
     )
 
     if isinstance(translations, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="episode_translations",
             resource_id=f"{params.show_id}/S{params.season:02d}E{params.episode:02d}",
             error_message=translations,
@@ -374,7 +374,7 @@ async def fetch_episode_lists(
     )
 
     if isinstance(lists, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="episode_lists",
             resource_id=f"{params.show_id}/S{params.season:02d}E{params.episode:02d}",
             error_message=lists,

--- a/server/episodes/tools.py
+++ b/server/episodes/tools.py
@@ -27,7 +27,6 @@ from config.mcp.descriptions import (
     SEASON_DESCRIPTION,
     SHOW_ID_DESCRIPTION,
 )
-from config.mcp.tools import TOOL_NAMES
 from models.formatters.episodes import EpisodeFormatters
 from models.formatters.videos import VideoFormatters
 from models.types.language import validate_language
@@ -396,7 +395,7 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
     """
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_episode_summary"],
+        name="fetch_episode_summary",
         description=(
             "Fetch detailed information about a specific TV show episode, "
             "including overview, air date, runtime, and ratings."
@@ -410,7 +409,7 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_episode_summary(show_id, season, episode)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_episode_ratings"],
+        name="fetch_episode_ratings",
         description=(
             "Fetch ratings and voting statistics for a specific TV show episode."
         ),
@@ -423,7 +422,7 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_episode_ratings(show_id, season, episode)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_episode_stats"],
+        name="fetch_episode_stats",
         description=(
             "Fetch engagement statistics for a specific TV show episode "
             "including watchers, plays, collectors, and comments."
@@ -437,7 +436,7 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_episode_stats(show_id, season, episode)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_episode_people"],
+        name="fetch_episode_people",
         description=(
             "Fetch cast and crew for a specific TV show episode, "
             "including character names and episode counts."
@@ -451,7 +450,7 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_episode_people(show_id, season, episode)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_episode_videos"],
+        name="fetch_episode_videos",
         description=(
             "Fetch videos (trailers, recaps, etc.) for a specific TV show episode. "
             "Set embed_markdown=False for simple links."
@@ -469,7 +468,7 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_episode_videos(show_id, season, episode, embed_markdown)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_episode_watching"],
+        name="fetch_episode_watching",
         description=(
             "Fetch users currently watching a specific TV show episode right now."
         ),
@@ -482,7 +481,7 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_episode_watching(show_id, season, episode)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_episode_translations"],
+        name="fetch_episode_translations",
         description=(
             "Fetch translations for a specific TV show episode in different languages."
         ),
@@ -496,7 +495,7 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_episode_translations(show_id, season, episode, language)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_episode_lists"],
+        name="fetch_episode_lists",
         description="Fetch lists that contain a specific TV show episode.",
     )
     async def fetch_episode_lists_tool(

--- a/server/movies/resources.py
+++ b/server/movies/resources.py
@@ -17,7 +17,7 @@ from client.pool import get_client
 from config.api import DEFAULT_LIMIT
 from config.mcp.resources import MCP_RESOURCES
 from models.formatters.movies import MovieFormatters
-from server.base import BaseToolErrorMixin, MovieIdParam
+from server.base import MovieIdParam, ToolErrors
 from utils.api.error_types import TraktValidationError
 from utils.api.errors import handle_api_errors_func
 
@@ -123,7 +123,7 @@ async def get_boxoffice_movies() -> str:
     client: MoviesClient = get_client(MoviesClient)
     movies = await client.get_boxoffice_movies()
     if isinstance(movies, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="boxoffice_movies",
             resource_id="weekend",
             error_message=movies,
@@ -178,7 +178,7 @@ async def get_movie_ratings(movie_id: str) -> str:
 
     # Handle transitional case where API returns error strings
     if isinstance(movie, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="movie",
             resource_id=movie_id,
             error_message=movie,
@@ -193,7 +193,7 @@ async def get_movie_ratings(movie_id: str) -> str:
 
     # Handle transitional case where API returns error strings
     if isinstance(ratings, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="movie_ratings",
             resource_id=movie_id,
             error_message=ratings,

--- a/server/movies/tools.py
+++ b/server/movies/tools.py
@@ -30,7 +30,7 @@ from config.mcp.descriptions import (
 )
 from models.formatters.movies import MovieFormatters
 from models.formatters.videos import VideoFormatters
-from server.base import BaseToolErrorMixin, LimitOnly, MovieIdParam, PeriodParams
+from server.base import LimitOnly, MovieIdParam, PeriodParams, ToolErrors
 from utils.api.errors import MCPError, handle_api_errors_func
 from utils.api.request_context import set_tool_context
 
@@ -74,7 +74,7 @@ async def fetch_trending_movies(
     client = get_client(TrendingMoviesClient)
     movies = await client.get_trending_movies(limit=limit, page=page)
     if isinstance(movies, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="trending_movies",
             resource_id="list",
             error_message=movies,
@@ -105,7 +105,7 @@ async def fetch_popular_movies(
     client = get_client(PopularMoviesClient)
     movies = await client.get_popular_movies(limit=limit, page=page)
     if isinstance(movies, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="popular_movies",
             resource_id="list",
             error_message=movies,
@@ -140,7 +140,7 @@ async def fetch_favorited_movies(
     client = get_client(MovieStatsClient)
     movies = await client.get_favorited_movies(limit=limit, period=period, page=page)
     if isinstance(movies, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="favorited_movies",
             resource_id="list",
             error_message=movies,
@@ -182,7 +182,7 @@ async def fetch_played_movies(
     client = get_client(MovieStatsClient)
     movies = await client.get_played_movies(limit=limit, period=period, page=page)
     if isinstance(movies, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="played_movies",
             resource_id="list",
             error_message=movies,
@@ -216,7 +216,7 @@ async def fetch_watched_movies(
     client = get_client(MovieStatsClient)
     movies = await client.get_watched_movies(limit=limit, period=period, page=page)
     if isinstance(movies, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="watched_movies",
             resource_id="list",
             error_message=movies,
@@ -247,7 +247,7 @@ async def fetch_anticipated_movies(
     client = get_client(AnticipatedMoviesClient)
     movies = await client.get_anticipated_movies(limit=limit, page=page)
     if isinstance(movies, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="anticipated_movies",
             resource_id="list",
             error_message=movies,
@@ -268,7 +268,7 @@ async def fetch_boxoffice_movies() -> str:
     client = get_client(BoxOfficeMoviesClient)
     movies = await client.get_boxoffice_movies()
     if isinstance(movies, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="boxoffice_movies",
             resource_id="weekend",
             error_message=movies,
@@ -303,7 +303,7 @@ async def fetch_movie_ratings(movie_id: str) -> str:
 
         # Handle transitional case where API returns error strings
         if isinstance(movie, str):
-            raise BaseToolErrorMixin.handle_api_string_error(
+            raise ToolErrors.handle_api_string_error(
                 resource_type="movie",
                 resource_id=movie_id,
                 error_message=movie,
@@ -316,7 +316,7 @@ async def fetch_movie_ratings(movie_id: str) -> str:
 
         # Handle transitional case where API returns error strings
         if isinstance(ratings, str):
-            raise BaseToolErrorMixin.handle_api_string_error(
+            raise ToolErrors.handle_api_string_error(
                 resource_type="movie_ratings",
                 resource_id=movie_id,
                 error_message=ratings,
@@ -360,7 +360,7 @@ async def fetch_movie_summary(movie_id: str, extended: bool = True) -> str:
             movie = await client.get_movie_extended(movie_id)
             # Handle transitional case where API returns error strings
             if isinstance(movie, str):
-                raise BaseToolErrorMixin.handle_api_string_error(
+                raise ToolErrors.handle_api_string_error(
                     resource_type="movie_extended",
                     resource_id=movie_id,
                     error_message=movie,
@@ -371,7 +371,7 @@ async def fetch_movie_summary(movie_id: str, extended: bool = True) -> str:
             movie = await client.get_movie(movie_id)
             # Handle transitional case where API returns error strings
             if isinstance(movie, str):
-                raise BaseToolErrorMixin.handle_api_string_error(
+                raise ToolErrors.handle_api_string_error(
                     resource_type="movie",
                     resource_id=movie_id,
                     error_message=movie,
@@ -404,7 +404,7 @@ async def fetch_movie_videos(movie_id: str, embed_markdown: bool = True) -> str:
         videos = await client.get_videos(movie_id)
         # Transitional safeguard if client returns string errors
         if isinstance(videos, str):
-            raise BaseToolErrorMixin.handle_api_string_error(
+            raise ToolErrors.handle_api_string_error(
                 resource_type="movie_videos",
                 resource_id=movie_id,
                 error_message=videos,
@@ -417,7 +417,7 @@ async def fetch_movie_videos(movie_id: str, embed_markdown: bool = True) -> str:
 
             # Handle transitional case where API returns error strings
             if isinstance(movie, str):
-                raise BaseToolErrorMixin.handle_api_string_error(
+                raise ToolErrors.handle_api_string_error(
                     resource_type="movie",
                     resource_id=movie_id,
                     error_message=movie,
@@ -474,7 +474,7 @@ async def fetch_related_movies(
         page=params.page,
     )
     if isinstance(movies, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="related_movies",
             resource_id=id_params.movie_id,
             error_message=movies,
@@ -537,7 +537,7 @@ async def fetch_movie_people(movie_id: str) -> str:
     )
 
     if isinstance(people, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="movie_people",
             resource_id=params.movie_id,
             error_message=people,

--- a/server/movies/tools.py
+++ b/server/movies/tools.py
@@ -28,7 +28,6 @@ from config.mcp.descriptions import (
     PAGE_DESCRIPTION,
     PERIOD_DESCRIPTION,
 )
-from config.mcp.tools import TOOL_NAMES
 from models.formatters.movies import MovieFormatters
 from models.formatters.videos import VideoFormatters
 from server.base import BaseToolErrorMixin, LimitOnly, MovieIdParam, PeriodParams
@@ -557,7 +556,7 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
     """
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_trending_movies"],
+        name="fetch_trending_movies",
         description=(
             "Fetch trending movies from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
@@ -570,7 +569,7 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_trending_movies(limit, page)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_popular_movies"],
+        name="fetch_popular_movies",
         description=(
             "Fetch popular movies from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
@@ -583,7 +582,7 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_popular_movies(limit, page)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_favorited_movies"],
+        name="fetch_favorited_movies",
         description=(
             "Fetch most favorited movies from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
@@ -600,7 +599,7 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_favorited_movies(limit, period, page)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_played_movies"],
+        name="fetch_played_movies",
         description=(
             "Fetch most played movies from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
@@ -617,7 +616,7 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_played_movies(limit, period, page)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_watched_movies"],
+        name="fetch_watched_movies",
         description=(
             "Fetch most watched movies from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
@@ -634,7 +633,7 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_watched_movies(limit, period, page)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_anticipated_movies"],
+        name="fetch_anticipated_movies",
         description=(
             "Fetch most anticipated movies from Trakt, sorted by list count. "
             "Use page parameter for paginated results, or omit for all results."
@@ -647,7 +646,7 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_anticipated_movies(limit, page)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_boxoffice_movies"],
+        name="fetch_boxoffice_movies",
         description=(
             "Fetch the top 10 grossing movies in the U.S. box office last weekend. "
             "Updated every Monday morning."
@@ -657,7 +656,7 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_boxoffice_movies()
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_movie_ratings"],
+        name="fetch_movie_ratings",
         description="Fetch ratings and voting statistics for a specific movie",
     )
     async def fetch_movie_ratings_tool(
@@ -668,7 +667,7 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_movie_ratings(params.movie_id)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_movie_summary"],
+        name="fetch_movie_summary",
         description=(
             "Get movie summary from Trakt. "
             "Default behavior (extended=true): Returns comprehensive data including "
@@ -685,7 +684,7 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_movie_summary(params.movie_id, params.extended)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_movie_videos"],
+        name="fetch_movie_videos",
         description=(
             "Get videos (trailers, teasers, etc.) for a movie from Trakt. "
             "Set embed_markdown=False to return simple links instead of "
@@ -705,7 +704,7 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_movie_videos(params.movie_id, params.embed_markdown)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_related_movies"],
+        name="fetch_related_movies",
         description=(
             "Fetch movies related to a specific movie. Returns similar movies "
             "based on genres, themes, and viewer patterns. "
@@ -720,7 +719,7 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_related_movies(movie_id, limit, page)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_movie_people"],
+        name="fetch_movie_people",
         description=(
             "Get cast and crew for a movie from Trakt. "
             "Returns cast with character names and crew "

--- a/server/people/tools.py
+++ b/server/people/tools.py
@@ -20,7 +20,7 @@ from config.mcp.descriptions import (
     PERSON_ID_DESCRIPTION,
 )
 from models.formatters.people import PeopleFormatters
-from server.base import BaseToolErrorMixin, PersonIdParam
+from server.base import PersonIdParam, ToolErrors
 from utils.api.errors import handle_api_errors_func
 from utils.api.request_context import set_tool_context
 
@@ -84,7 +84,7 @@ async def fetch_person_summary(person_id: str, extended: bool = True) -> str:
         person = await client.get_person(params.person_id)
 
     if isinstance(person, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="person",
             resource_id=params.person_id,
             error_message=person,
@@ -114,7 +114,7 @@ async def fetch_person_movies(person_id: str) -> str:
     )
 
     if isinstance(movie_credits, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="person_movies",
             resource_id=params.person_id,
             error_message=movie_credits,
@@ -145,7 +145,7 @@ async def fetch_person_shows(person_id: str) -> str:
     )
 
     if isinstance(show_credits, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="person_shows",
             resource_id=params.person_id,
             error_message=show_credits,
@@ -184,7 +184,7 @@ async def fetch_person_lists(
     )
 
     if isinstance(lists, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="person_lists",
             resource_id=params.person_id,
             error_message=lists,

--- a/server/people/tools.py
+++ b/server/people/tools.py
@@ -19,7 +19,6 @@ from config.mcp.descriptions import (
     LIST_TYPE_DESCRIPTION,
     PERSON_ID_DESCRIPTION,
 )
-from config.mcp.tools import TOOL_NAMES
 from models.formatters.people import PeopleFormatters
 from server.base import BaseToolErrorMixin, PersonIdParam
 from utils.api.errors import handle_api_errors_func
@@ -206,7 +205,7 @@ def register_people_tools(
     """
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_person_summary"],
+        name="fetch_person_summary",
         description=(
             "Get person details from Trakt. "
             "Default (extended=true): full biographical data including "
@@ -224,7 +223,7 @@ def register_people_tools(
         return await fetch_person_summary(person_id, extended)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_person_movies"],
+        name="fetch_person_movies",
         description=(
             "Get all movie credits for a person from Trakt. "
             "Returns cast roles and crew positions grouped by "
@@ -240,7 +239,7 @@ def register_people_tools(
         return await fetch_person_movies(person_id)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_person_shows"],
+        name="fetch_person_shows",
         description=(
             "Get all show credits for a person from Trakt. "
             "Returns cast roles with episode counts and crew "
@@ -256,7 +255,7 @@ def register_people_tools(
         return await fetch_person_shows(person_id)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_person_lists"],
+        name="fetch_person_lists",
         description=(
             "Get lists containing a specific person from Trakt. "
             "Returns personal or official lists sorted by "

--- a/server/progress/tools.py
+++ b/server/progress/tools.py
@@ -80,13 +80,12 @@ async def fetch_show_progress(
 
     # Handle transitional case where API returns error strings
     if isinstance(result, str):
-        error = ToolErrors.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="show_progress",
             resource_id=show_id,
             error_message=result,
             operation="fetch_show_progress",
         )
-        raise error
 
     return ProgressFormatters.format_show_progress(result, show_id, verbose=verbose)
 
@@ -114,13 +113,12 @@ async def fetch_playback_progress(
 
     # Handle transitional case where API returns error strings
     if isinstance(result, str):
-        error = ToolErrors.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="playback_progress",
             resource_id=playback_type or "all",
             error_message=result,
             operation="fetch_playback_progress",
         )
-        raise error
 
     return ProgressFormatters.format_playback_progress(result)
 

--- a/server/progress/tools.py
+++ b/server/progress/tools.py
@@ -19,7 +19,6 @@ from config.mcp.descriptions import (
     SHOW_PROGRESS_SPECIALS_DESCRIPTION,
     SHOW_PROGRESS_VERBOSE_DESCRIPTION,
 )
-from config.mcp.tools.progress import PROGRESS_TOOLS
 from models.formatters.progress import ProgressFormatters
 from server.base import BaseToolErrorMixin, ShowIdParam
 from utils.api.errors import handle_api_errors_func
@@ -161,7 +160,7 @@ def register_progress_tools(
     """
 
     @mcp.tool(
-        name=PROGRESS_TOOLS["fetch_show_progress"],
+        name="fetch_show_progress",
         description=(
             "Check if a user has watched a specific TV show and their progress "
             "through it. "
@@ -197,7 +196,7 @@ def register_progress_tools(
         )
 
     @mcp.tool(
-        name=PROGRESS_TOOLS["fetch_playback_progress"],
+        name="fetch_playback_progress",
         description=(
             "Fetch paused playback progress items. Shows movies and episodes "
             "that were paused during playback with their progress percentage. "
@@ -213,7 +212,7 @@ def register_progress_tools(
         return await fetch_playback_progress(playback_type)
 
     @mcp.tool(
-        name=PROGRESS_TOOLS["remove_playback_item"],
+        name="remove_playback_item",
         description=(
             "Remove a paused playback progress item. Use the ID from "
             "fetch_playback_progress results. Requires OAuth authentication."

--- a/server/progress/tools.py
+++ b/server/progress/tools.py
@@ -20,7 +20,7 @@ from config.mcp.descriptions import (
     SHOW_PROGRESS_VERBOSE_DESCRIPTION,
 )
 from models.formatters.progress import ProgressFormatters
-from server.base import BaseToolErrorMixin, ShowIdParam
+from server.base import ShowIdParam, ToolErrors
 from utils.api.errors import handle_api_errors_func
 from utils.api.request_context import set_tool_context
 
@@ -80,7 +80,7 @@ async def fetch_show_progress(
 
     # Handle transitional case where API returns error strings
     if isinstance(result, str):
-        error = BaseToolErrorMixin.handle_api_string_error(
+        error = ToolErrors.handle_api_string_error(
             resource_type="show_progress",
             resource_id=show_id,
             error_message=result,
@@ -114,7 +114,7 @@ async def fetch_playback_progress(
 
     # Handle transitional case where API returns error strings
     if isinstance(result, str):
-        error = BaseToolErrorMixin.handle_api_string_error(
+        error = ToolErrors.handle_api_string_error(
             resource_type="playback_progress",
             resource_id=playback_type or "all",
             error_message=result,

--- a/server/recommendations/tools.py
+++ b/server/recommendations/tools.py
@@ -18,7 +18,7 @@ from config.mcp.descriptions import (
     SHOW_ID_DESCRIPTION,
 )
 from models.formatters.recommendations import RecommendationFormatters
-from server.base import BaseToolErrorMixin
+from server.base import ToolErrors
 from utils.api.errors import handle_api_errors_func
 from utils.api.request_context import set_tool_context
 from utils.validators import StrippedStr
@@ -93,7 +93,7 @@ async def fetch_movie_recommendations(
 
     # Handle transitional case where API returns error strings
     if isinstance(recommendations, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="movie_recommendations",
             resource_id="recommendations",
             error_message=recommendations,
@@ -141,7 +141,7 @@ async def fetch_show_recommendations(
 
     # Handle transitional case where API returns error strings
     if isinstance(recommendations, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="show_recommendations",
             resource_id="recommendations",
             error_message=recommendations,

--- a/server/recommendations/tools.py
+++ b/server/recommendations/tools.py
@@ -17,7 +17,6 @@ from config.mcp.descriptions import (
     RECOMMENDATIONS_LIMIT_DESCRIPTION,
     SHOW_ID_DESCRIPTION,
 )
-from config.mcp.tools import TOOL_NAMES
 from models.formatters.recommendations import RecommendationFormatters
 from server.base import BaseToolErrorMixin
 from utils.api.errors import handle_api_errors_func
@@ -252,7 +251,7 @@ def register_recommendation_tools(
     """
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_movie_recommendations"],
+        name="fetch_movie_recommendations",
         description=(
             "Fetch personalized movie recommendations from Trakt based on your "
             "viewing history. Requires OAuth authentication. Use limit parameter "
@@ -278,7 +277,7 @@ def register_recommendation_tools(
         )
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_show_recommendations"],
+        name="fetch_show_recommendations",
         description=(
             "Fetch personalized TV show recommendations from Trakt based on your "
             "viewing history. Requires OAuth authentication. Use limit parameter "
@@ -303,7 +302,7 @@ def register_recommendation_tools(
         )
 
     @mcp.tool(
-        name=TOOL_NAMES["hide_movie_recommendation"],
+        name="hide_movie_recommendation",
         description=(
             "Hide a movie from future recommendations. Requires OAuth authentication. "
             "Use Trakt ID, slug, or IMDB ID to identify the movie."
@@ -316,7 +315,7 @@ def register_recommendation_tools(
         return await hide_movie_recommendation(movie_id)
 
     @mcp.tool(
-        name=TOOL_NAMES["hide_show_recommendation"],
+        name="hide_show_recommendation",
         description=(
             "Hide a TV show from future recommendations. "
             "Requires OAuth authentication. "
@@ -330,7 +329,7 @@ def register_recommendation_tools(
         return await hide_show_recommendation(show_id)
 
     @mcp.tool(
-        name=TOOL_NAMES["unhide_movie_recommendation"],
+        name="unhide_movie_recommendation",
         description=(
             "Unhide a movie to restore it in future recommendations. "
             "Requires OAuth authentication. "
@@ -344,7 +343,7 @@ def register_recommendation_tools(
         return await unhide_movie_recommendation(movie_id)
 
     @mcp.tool(
-        name=TOOL_NAMES["unhide_show_recommendation"],
+        name="unhide_show_recommendation",
         description=(
             "Unhide a TV show to restore it in future recommendations. "
             "Requires OAuth authentication. "

--- a/server/search/tools.py
+++ b/server/search/tools.py
@@ -14,7 +14,6 @@ from config.mcp.descriptions import (
     SEARCH_LIMIT_DESCRIPTION,
     SEARCH_QUERY_DESCRIPTION,
 )
-from config.mcp.tools import TOOL_NAMES
 from models.formatters.search import SearchFormatters
 from server.base import BaseToolErrorMixin, LimitPageValidatorMixin
 from utils.api.errors import MCPError, handle_api_errors_func
@@ -192,7 +191,7 @@ def register_search_tools(
     """
 
     @mcp.tool(
-        name=TOOL_NAMES["search_shows"],
+        name="search_shows",
         description="Search for TV shows on Trakt by title",
     )
     async def search_shows_tool(
@@ -208,7 +207,7 @@ def register_search_tools(
         return await search_shows(query, limit, page)
 
     @mcp.tool(
-        name=TOOL_NAMES["search_movies"],
+        name="search_movies",
         description="Search for movies on Trakt by title",
     )
     async def search_movies_tool(

--- a/server/search/tools.py
+++ b/server/search/tools.py
@@ -15,7 +15,7 @@ from config.mcp.descriptions import (
     SEARCH_QUERY_DESCRIPTION,
 )
 from models.formatters.search import SearchFormatters
-from server.base import BaseToolErrorMixin, LimitPageValidatorMixin
+from server.base import LimitPageValidatorMixin, ToolErrors
 from utils.api.errors import MCPError, handle_api_errors_func
 
 # Type alias for search tool handlers
@@ -76,7 +76,7 @@ def _validate_search_params(
         summary = "Invalid parameters for search: " + "; ".join(
             f"{ve['field']}: {ve['message']}" for ve in validation_errors
         )
-        raise BaseToolErrorMixin.handle_validation_error(
+        raise ToolErrors.handle_validation_error(
             summary, validation_errors=validation_errors, operation=operation
         ) from e
     else:
@@ -116,7 +116,7 @@ async def _run_search(
     except MCPError:
         raise
     except Exception as e:
-        raise BaseToolErrorMixin.handle_unexpected_error(
+        raise ToolErrors.handle_unexpected_error(
             operation=op, error=e, query=q, limit=lim, page=p
         ) from e
 

--- a/server/seasons/tools.py
+++ b/server/seasons/tools.py
@@ -30,7 +30,7 @@ from config.mcp.descriptions import (
 from models.formatters.seasons import SeasonFormatters
 from models.formatters.videos import VideoFormatters
 from models.types.language import validate_language
-from server.base import BaseToolErrorMixin, SeasonIdParam
+from server.base import SeasonIdParam, ToolErrors
 from utils.api.errors import handle_api_errors_func
 from utils.api.request_context import set_tool_context
 
@@ -101,7 +101,7 @@ async def fetch_season_info(show_id: str, season: int) -> str:
     )
 
     if isinstance(season_data, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="season",
             resource_id=f"{params.show_id}/S{params.season:02d}",
             error_message=season_data,
@@ -131,7 +131,7 @@ async def fetch_season_episodes(show_id: str, season: int) -> str:
     )
 
     if isinstance(episodes, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="season_episodes",
             resource_id=f"{params.show_id}/S{params.season:02d}",
             error_message=episodes,
@@ -162,7 +162,7 @@ async def fetch_season_ratings(show_id: str, season: int) -> str:
     )
 
     if isinstance(ratings, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="season_ratings",
             resource_id=f"{params.show_id}/S{params.season:02d}",
             error_message=ratings,
@@ -194,7 +194,7 @@ async def fetch_season_stats(show_id: str, season: int) -> str:
     )
 
     if isinstance(stats, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="season_stats",
             resource_id=f"{params.show_id}/S{params.season:02d}",
             error_message=stats,
@@ -226,7 +226,7 @@ async def fetch_season_people(show_id: str, season: int) -> str:
     )
 
     if isinstance(people, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="season_people",
             resource_id=f"{params.show_id}/S{params.season:02d}",
             error_message=people,
@@ -261,7 +261,7 @@ async def fetch_season_videos(
     )
 
     if isinstance(videos, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="season_videos",
             resource_id=f"{params.show_id}/S{params.season:02d}",
             error_message=videos,
@@ -295,7 +295,7 @@ async def fetch_season_watching(show_id: str, season: int) -> str:
     )
 
     if isinstance(users, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="season_watching",
             resource_id=f"{params.show_id}/S{params.season:02d}",
             error_message=users,
@@ -326,7 +326,7 @@ async def fetch_season_translations(
     try:
         language = validate_language(language)
     except ValueError as err:
-        raise BaseToolErrorMixin.handle_validation_error(
+        raise ToolErrors.handle_validation_error(
             INVALID_LANGUAGE_MSG,
             parameter="language",
             provided_value=language,
@@ -341,7 +341,7 @@ async def fetch_season_translations(
     )
 
     if isinstance(translations, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="season_translations",
             resource_id=f"{params.show_id}/S{params.season:02d}",
             error_message=translations,
@@ -384,7 +384,7 @@ async def fetch_season_lists(
     )
 
     if isinstance(lists, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="season_lists",
             resource_id=f"{params.show_id}/S{params.season:02d}",
             error_message=lists,

--- a/server/seasons/tools.py
+++ b/server/seasons/tools.py
@@ -27,7 +27,6 @@ from config.mcp.descriptions import (
     SEASON_DESCRIPTION,
     SHOW_ID_DESCRIPTION,
 )
-from config.mcp.tools import TOOL_NAMES
 from models.formatters.seasons import SeasonFormatters
 from models.formatters.videos import VideoFormatters
 from models.types.language import validate_language
@@ -404,7 +403,7 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
     """
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_season_info"],
+        name="fetch_season_info",
         description=(
             "Fetch detailed information about a specific TV show season, "
             "including episode count, ratings, and air dates."
@@ -417,7 +416,7 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_season_info(show_id, season)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_season_episodes"],
+        name="fetch_season_episodes",
         description=(
             "Fetch all episodes for a specific TV show season "
             "with titles, ratings, and runtime."
@@ -430,7 +429,7 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_season_episodes(show_id, season)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_season_ratings"],
+        name="fetch_season_ratings",
         description=(
             "Fetch ratings and voting statistics for a specific TV show season."
         ),
@@ -442,7 +441,7 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_season_ratings(show_id, season)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_season_stats"],
+        name="fetch_season_stats",
         description=(
             "Fetch engagement statistics for a specific TV show season "
             "including watchers, plays, collectors, and comments."
@@ -455,7 +454,7 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_season_stats(show_id, season)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_season_people"],
+        name="fetch_season_people",
         description=(
             "Fetch cast and crew for a specific TV show season, "
             "including character names and episode counts."
@@ -468,7 +467,7 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_season_people(show_id, season)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_season_videos"],
+        name="fetch_season_videos",
         description=(
             "Fetch videos (trailers, recaps, etc.) for a specific TV show season. "
             "Set embed_markdown=False for simple links."
@@ -485,7 +484,7 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_season_videos(show_id, season, embed_markdown)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_season_watching"],
+        name="fetch_season_watching",
         description=(
             "Fetch users currently watching a specific TV show season right now."
         ),
@@ -497,7 +496,7 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_season_watching(show_id, season)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_season_translations"],
+        name="fetch_season_translations",
         description=(
             "Fetch translations for a specific TV show season in different languages."
         ),
@@ -510,7 +509,7 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_season_translations(show_id, season, language)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_season_lists"],
+        name="fetch_season_lists",
         description="Fetch lists that contain a specific TV show season.",
     )
     async def fetch_season_lists_tool(

--- a/server/shows/resources.py
+++ b/server/shows/resources.py
@@ -17,7 +17,7 @@ from client.shows.client import ShowsClient
 from config.api import DEFAULT_LIMIT
 from config.mcp.resources import MCP_RESOURCES
 from models.formatters.shows import ShowFormatters
-from server.base import BaseToolErrorMixin, ShowIdParam
+from server.base import ShowIdParam, ToolErrors
 from utils.api.error_types import TraktValidationError
 from utils.api.errors import handle_api_errors_func
 
@@ -39,7 +39,7 @@ async def get_trending_shows() -> str:
     client: ShowsClient = get_client(ShowsClient)
     shows = await client.get_trending_shows(limit=DEFAULT_LIMIT)
     if isinstance(shows, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="trending_shows",
             resource_id="list",
             error_message=shows,
@@ -60,7 +60,7 @@ async def get_popular_shows() -> str:
     client: ShowsClient = get_client(ShowsClient)
     shows = await client.get_popular_shows(limit=DEFAULT_LIMIT)
     if isinstance(shows, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="popular_shows",
             resource_id="list",
             error_message=shows,
@@ -81,7 +81,7 @@ async def get_favorited_shows() -> str:
     client: ShowsClient = get_client(ShowsClient)
     shows = await client.get_favorited_shows(limit=DEFAULT_LIMIT)
     if isinstance(shows, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="favorited_shows",
             resource_id="list",
             error_message=shows,
@@ -115,7 +115,7 @@ async def get_played_shows() -> str:
     client: ShowsClient = get_client(ShowsClient)
     shows = await client.get_played_shows(limit=DEFAULT_LIMIT)
     if isinstance(shows, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="played_shows",
             resource_id="list",
             error_message=shows,
@@ -137,7 +137,7 @@ async def get_watched_shows() -> str:
     client: ShowsClient = get_client(ShowsClient)
     shows = await client.get_watched_shows(limit=DEFAULT_LIMIT)
     if isinstance(shows, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="watched_shows",
             resource_id="list",
             error_message=shows,
@@ -158,7 +158,7 @@ async def get_anticipated_shows() -> str:
     client: ShowsClient = get_client(ShowsClient)
     shows = await client.get_anticipated_shows(limit=DEFAULT_LIMIT)
     if isinstance(shows, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="anticipated_shows",
             resource_id="list",
             error_message=shows,
@@ -199,7 +199,7 @@ async def get_show_ratings(show_id: str) -> str:
 
     # Handle transitional case where API returns error strings
     if isinstance(show, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="show",
             resource_id=show_id,
             error_message=show,
@@ -213,7 +213,7 @@ async def get_show_ratings(show_id: str) -> str:
 
     # Handle transitional case where API returns error strings
     if isinstance(ratings, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="show_ratings",
             resource_id=show_id,
             error_message=ratings,

--- a/server/shows/tools.py
+++ b/server/shows/tools.py
@@ -30,7 +30,7 @@ from config.mcp.descriptions import (
 )
 from models.formatters.shows import ShowFormatters
 from models.formatters.videos import VideoFormatters
-from server.base import BaseToolErrorMixin, LimitOnly, PeriodParams, ShowIdParam
+from server.base import LimitOnly, PeriodParams, ShowIdParam, ToolErrors
 from utils.api.errors import MCPError, handle_api_errors_func
 from utils.api.request_context import set_tool_context
 
@@ -74,7 +74,7 @@ async def fetch_trending_shows(
     client = get_client(TrendingShowsClient)
     shows = await client.get_trending_shows(limit=limit, page=page)
     if isinstance(shows, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="trending_shows",
             resource_id="list",
             error_message=shows,
@@ -105,7 +105,7 @@ async def fetch_popular_shows(
     client = get_client(PopularShowsClient)
     shows = await client.get_popular_shows(limit=limit, page=page)
     if isinstance(shows, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="popular_shows",
             resource_id="list",
             error_message=shows,
@@ -140,7 +140,7 @@ async def fetch_favorited_shows(
     client = get_client(ShowStatsClient)
     shows = await client.get_favorited_shows(limit=limit, period=period, page=page)
     if isinstance(shows, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="favorited_shows",
             resource_id="list",
             error_message=shows,
@@ -181,7 +181,7 @@ async def fetch_played_shows(
     client = get_client(ShowStatsClient)
     shows = await client.get_played_shows(limit=limit, period=period, page=page)
     if isinstance(shows, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="played_shows",
             resource_id="list",
             error_message=shows,
@@ -215,7 +215,7 @@ async def fetch_watched_shows(
     client = get_client(ShowStatsClient)
     shows = await client.get_watched_shows(limit=limit, period=period, page=page)
     if isinstance(shows, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="watched_shows",
             resource_id="list",
             error_message=shows,
@@ -246,7 +246,7 @@ async def fetch_anticipated_shows(
     client = get_client(AnticipatedShowsClient)
     shows = await client.get_anticipated_shows(limit=limit, page=page)
     if isinstance(shows, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="anticipated_shows",
             resource_id="list",
             error_message=shows,
@@ -281,7 +281,7 @@ async def fetch_show_ratings(show_id: str) -> str:
 
         # Handle transitional case where API returns error strings
         if isinstance(show_data, str):
-            raise BaseToolErrorMixin.handle_api_string_error(
+            raise ToolErrors.handle_api_string_error(
                 resource_type="show",
                 resource_id=show_id,
                 error_message=show_data,
@@ -293,7 +293,7 @@ async def fetch_show_ratings(show_id: str) -> str:
 
         # Handle transitional case where API returns error strings
         if isinstance(ratings, str):
-            raise BaseToolErrorMixin.handle_api_string_error(
+            raise ToolErrors.handle_api_string_error(
                 resource_type="show_ratings",
                 resource_id=show_id,
                 error_message=ratings,
@@ -338,7 +338,7 @@ async def fetch_show_summary(show_id: str, extended: bool = True) -> str:
             show_data = await client.get_show_extended(show_id)
             # Handle transitional case where API returns error strings
             if isinstance(show_data, str):
-                raise BaseToolErrorMixin.handle_api_string_error(
+                raise ToolErrors.handle_api_string_error(
                     resource_type="show_extended",
                     resource_id=show_id,
                     error_message=show_data,
@@ -349,7 +349,7 @@ async def fetch_show_summary(show_id: str, extended: bool = True) -> str:
             show_data = await client.get_show(show_id)
             # Handle transitional case where API returns error strings
             if isinstance(show_data, str):
-                raise BaseToolErrorMixin.handle_api_string_error(
+                raise ToolErrors.handle_api_string_error(
                     resource_type="show",
                     resource_id=show_id,
                     error_message=show_data,
@@ -381,7 +381,7 @@ async def fetch_show_videos(show_id: str, embed_markdown: bool = True) -> str:
         videos = await client.get_videos(show_id)
 
         if isinstance(videos, str):
-            raise BaseToolErrorMixin.handle_api_string_error(
+            raise ToolErrors.handle_api_string_error(
                 resource_type="show_videos",
                 resource_id=show_id,
                 error_message=videos,
@@ -455,7 +455,7 @@ async def fetch_related_shows(
         page=params.page,
     )
     if isinstance(shows, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="related_shows",
             resource_id=id_params.show_id,
             error_message=shows,
@@ -483,7 +483,7 @@ async def fetch_show_seasons(show_id: str) -> str:
     client = get_client(ShowsClient)
     seasons = await client.get_seasons(show_id)
     if isinstance(seasons, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="show_seasons",
             resource_id=show_id,
             error_message=seasons,
@@ -549,7 +549,7 @@ async def fetch_show_people(show_id: str, include_guest_stars: bool = False) -> 
     )
 
     if isinstance(people, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="show_people",
             resource_id=params.show_id,
             error_message=people,

--- a/server/shows/tools.py
+++ b/server/shows/tools.py
@@ -28,7 +28,6 @@ from config.mcp.descriptions import (
     PERIOD_DESCRIPTION,
     SHOW_ID_DESCRIPTION,
 )
-from config.mcp.tools import TOOL_NAMES
 from models.formatters.shows import ShowFormatters
 from models.formatters.videos import VideoFormatters
 from server.base import BaseToolErrorMixin, LimitOnly, PeriodParams, ShowIdParam
@@ -569,7 +568,7 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
     """
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_trending_shows"],
+        name="fetch_trending_shows",
         description=(
             "Fetch trending TV shows from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
@@ -582,7 +581,7 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_trending_shows(limit, page)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_popular_shows"],
+        name="fetch_popular_shows",
         description=(
             "Fetch popular TV shows from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
@@ -595,7 +594,7 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_popular_shows(limit, page)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_favorited_shows"],
+        name="fetch_favorited_shows",
         description=(
             "Fetch most favorited TV shows from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
@@ -612,7 +611,7 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_favorited_shows(limit, period, page)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_played_shows"],
+        name="fetch_played_shows",
         description=(
             "Fetch most played TV shows from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
@@ -629,7 +628,7 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_played_shows(limit, period, page)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_watched_shows"],
+        name="fetch_watched_shows",
         description=(
             "Fetch most watched TV shows from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
@@ -646,7 +645,7 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_watched_shows(limit, period, page)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_anticipated_shows"],
+        name="fetch_anticipated_shows",
         description=(
             "Fetch most anticipated TV shows from Trakt, sorted by list count. "
             "Use page parameter for paginated results, or omit for all results."
@@ -659,7 +658,7 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_anticipated_shows(limit, page)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_show_ratings"],
+        name="fetch_show_ratings",
         description="Fetch ratings and voting statistics for a specific TV show",
     )
     async def fetch_show_ratings_tool(
@@ -670,7 +669,7 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_show_ratings(params.show_id)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_show_summary"],
+        name="fetch_show_summary",
         description=(
             "Get TV show summary from Trakt. "
             "Default behavior (extended=true): Returns comprehensive data including "
@@ -688,7 +687,7 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_show_summary(params.show_id, params.extended)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_show_videos"],
+        name="fetch_show_videos",
         description=(
             "Get videos (trailers, teasers, etc.) for a show from Trakt. "
             "Set embed_markdown=False to return simple links instead of "
@@ -708,7 +707,7 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_show_videos(params.show_id, params.embed_markdown)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_related_shows"],
+        name="fetch_related_shows",
         description=(
             "Fetch TV shows related to a specific show. Returns similar shows "
             "based on genres, themes, and viewer patterns. "
@@ -723,7 +722,7 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_related_shows(show_id, limit, page)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_show_seasons"],
+        name="fetch_show_seasons",
         description=(
             "Fetch all seasons for a TV show from Trakt, including episode counts, "
             "aired episodes, and ratings per season."
@@ -735,7 +734,7 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         return await fetch_show_seasons(show_id)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_show_people"],
+        name="fetch_show_people",
         description=(
             "Get cast and crew for a TV show from Trakt. "
             "Set include_guest_stars=true to also return guest stars "

--- a/server/sync/tools.py
+++ b/server/sync/tools.py
@@ -32,7 +32,6 @@ from config.mcp.descriptions import (
     WATCHLIST_TYPE_DESCRIPTION,
     WATCHLIST_TYPE_REQUIRED_DESCRIPTION,
 )
-from config.mcp.tools.sync import SYNC_TOOLS
 from models.formatters.sync_history import SyncHistoryFormatters
 from models.formatters.sync_ratings import SyncRatingsFormatters
 from models.formatters.sync_watchlist import SyncWatchlistFormatters
@@ -924,7 +923,7 @@ def register_sync_tools(
     """
 
     @mcp.tool(
-        name=SYNC_TOOLS["fetch_user_ratings"],
+        name="fetch_user_ratings",
         description=(
             "Fetch the authenticated user's personal ratings from Trakt. "
             "Supports optional pagination with 'page' parameter. "
@@ -950,7 +949,7 @@ def register_sync_tools(
         return await fetch_user_ratings(params.rating_type, params.rating, params.page)
 
     @mcp.tool(
-        name=SYNC_TOOLS["add_user_ratings"],
+        name="add_user_ratings",
         description=(
             "Add new ratings for the authenticated user. Requires OAuth authentication."
         ),
@@ -971,7 +970,7 @@ def register_sync_tools(
         return await add_user_ratings(rating_type, items)
 
     @mcp.tool(
-        name=SYNC_TOOLS["remove_user_ratings"],
+        name="remove_user_ratings",
         description=(
             "Remove ratings for the authenticated user. Requires OAuth authentication."
         ),
@@ -992,7 +991,7 @@ def register_sync_tools(
         return await remove_user_ratings(rating_type, items)
 
     @mcp.tool(
-        name=SYNC_TOOLS["fetch_user_watchlist"],
+        name="fetch_user_watchlist",
         description=(
             "Fetch the authenticated user's watchlist from Trakt. "
             "Supports optional pagination with 'page' parameter and sorting options. "
@@ -1026,7 +1025,7 @@ def register_sync_tools(
         )
 
     @mcp.tool(
-        name=SYNC_TOOLS["add_user_watchlist"],
+        name="add_user_watchlist",
         description=(
             "Add items to the authenticated user's watchlist. "
             "Supports optional notes (VIP only, 500 character limit). "
@@ -1049,7 +1048,7 @@ def register_sync_tools(
         return await add_user_watchlist(watchlist_type, items)
 
     @mcp.tool(
-        name=SYNC_TOOLS["remove_user_watchlist"],
+        name="remove_user_watchlist",
         description=(
             "Remove items from the authenticated user's watchlist. "
             "Requires OAuth authentication."
@@ -1071,7 +1070,7 @@ def register_sync_tools(
         return await remove_user_watchlist(watchlist_type, items)
 
     @mcp.tool(
-        name=SYNC_TOOLS["fetch_history"],
+        name="fetch_history",
         description=(
             "Check if a movie or show has been watched, or browse watch history. "
             "For 'Have I seen [movie]?': provide history_type='movies' and item_id. "
@@ -1105,7 +1104,7 @@ def register_sync_tools(
         return await fetch_history(history_type, item_id, start_at, end_at, page)
 
     @mcp.tool(
-        name=SYNC_TOOLS["add_to_history"],
+        name="add_to_history",
         description=(
             "Add items to watch history. Marks movies, shows, seasons, or episodes "
             "as watched. Optionally specify when they were watched. "
@@ -1125,7 +1124,7 @@ def register_sync_tools(
         return await add_to_history(history_type, items)
 
     @mcp.tool(
-        name=SYNC_TOOLS["remove_from_history"],
+        name="remove_from_history",
         description=(
             "Remove items from watch history. Removes movies, shows, seasons, "
             "or episodes from your watched history. "

--- a/server/sync/tools.py
+++ b/server/sync/tools.py
@@ -52,7 +52,7 @@ from models.sync.watchlist import (
 )
 from models.types.ids import TraktIds
 from models.types.pagination import PaginationParams
-from server.base import BaseToolErrorMixin, IdentifierValidatorMixin
+from server.base import IdentifierValidatorMixin, ToolErrors
 from utils.api.errors import MCPError, handle_api_errors_func
 
 logger = logging.getLogger("trakt_mcp")
@@ -133,7 +133,7 @@ async def _batch_show_history_op(
             request = TraktHistoryRequest(shows=[item])
             result = await client_method(request)
             if isinstance(result, str):
-                raise BaseToolErrorMixin.handle_api_string_error(
+                raise ToolErrors.handle_api_string_error(
                     resource_type="sync_history_show",
                     resource_id="unknown",
                     error_message=result,
@@ -152,7 +152,7 @@ async def _batch_show_history_op(
             request = TraktHistoryRequest(shows=[item])
             result = await client_method(request)
             if isinstance(result, str):
-                raise BaseToolErrorMixin.handle_api_string_error(
+                raise ToolErrors.handle_api_string_error(
                     resource_type="sync_history_show",
                     resource_id=show_id,
                     error_message=result,
@@ -169,7 +169,7 @@ async def _batch_show_history_op(
             request = TraktHistoryRequest(shows=[item])
             result = await client_method(request)
             if isinstance(result, str):
-                raise BaseToolErrorMixin.handle_api_string_error(
+                raise ToolErrors.handle_api_string_error(
                     resource_type="sync_history_show",
                     resource_id=show_id,
                     error_message=result,
@@ -192,7 +192,7 @@ async def _batch_show_history_op(
             try:
                 result = await client_method(request)
                 if isinstance(result, str):
-                    raise BaseToolErrorMixin.handle_api_string_error(
+                    raise ToolErrors.handle_api_string_error(
                         resource_type="sync_history_season",
                         resource_id=str(season_id),
                         error_message=result,
@@ -376,7 +376,7 @@ async def fetch_user_ratings(
 
         # Handle transitional case where API returns error strings
         if isinstance(paginated_result, str):
-            error = BaseToolErrorMixin.handle_api_string_error(
+            error = ToolErrors.handle_api_string_error(
                 resource_type=f"user_{rating_type}_ratings",
                 resource_id=f"user_ratings_{rating_type}",
                 error_message=paginated_result,
@@ -438,7 +438,7 @@ async def add_user_ratings(
 
         # Handle transitional case where API returns error strings
         if isinstance(summary, str):
-            error = BaseToolErrorMixin.handle_api_string_error(
+            error = ToolErrors.handle_api_string_error(
                 resource_type=f"add_user_{rating_type}_ratings",
                 resource_id=f"add_ratings_{rating_type}",
                 error_message=summary,
@@ -498,7 +498,7 @@ async def remove_user_ratings(
 
         # Handle transitional case where API returns error strings
         if isinstance(summary, str):
-            error = BaseToolErrorMixin.handle_api_string_error(
+            error = ToolErrors.handle_api_string_error(
                 resource_type=f"remove_user_{rating_type}_ratings",
                 resource_id=f"remove_ratings_{rating_type}",
                 error_message=summary,
@@ -563,7 +563,7 @@ async def fetch_user_watchlist(
 
         # Handle transitional case where API returns error strings
         if isinstance(paginated_result, str):
-            error = BaseToolErrorMixin.handle_api_string_error(
+            error = ToolErrors.handle_api_string_error(
                 resource_type=f"user_{watchlist_type}_watchlist",
                 resource_id=f"user_watchlist_{watchlist_type}",
                 error_message=paginated_result,
@@ -626,7 +626,7 @@ async def add_user_watchlist(
 
         # Handle transitional case where API returns error strings
         if isinstance(summary, str):
-            error = BaseToolErrorMixin.handle_api_string_error(
+            error = ToolErrors.handle_api_string_error(
                 resource_type=f"add_user_{watchlist_type}_watchlist",
                 resource_id=f"add_watchlist_{watchlist_type}",
                 error_message=summary,
@@ -686,7 +686,7 @@ async def remove_user_watchlist(
 
         # Handle transitional case where API returns error strings
         if isinstance(summary, str):
-            error = BaseToolErrorMixin.handle_api_string_error(
+            error = ToolErrors.handle_api_string_error(
                 resource_type=f"remove_user_{watchlist_type}_watchlist",
                 resource_id=f"remove_watchlist_{watchlist_type}",
                 error_message=summary,
@@ -779,7 +779,7 @@ async def fetch_history(
 
     # Handle transitional case where API returns error strings
     if isinstance(result, str):
-        error = BaseToolErrorMixin.handle_api_string_error(
+        error = ToolErrors.handle_api_string_error(
             resource_type="history",
             resource_id=params.item_id or "all",
             error_message=result,
@@ -836,7 +836,7 @@ async def add_to_history(
 
     # Handle transitional case where API returns error strings
     if isinstance(summary, str):
-        error = BaseToolErrorMixin.handle_api_string_error(
+        error = ToolErrors.handle_api_string_error(
             resource_type=f"add_history_{history_type}",
             resource_id=f"add_history_{history_type}",
             error_message=summary,
@@ -890,7 +890,7 @@ async def remove_from_history(
 
     # Handle transitional case where API returns error strings
     if isinstance(summary, str):
-        error = BaseToolErrorMixin.handle_api_string_error(
+        error = ToolErrors.handle_api_string_error(
             resource_type=f"remove_history_{history_type}",
             resource_id=f"remove_history_{history_type}",
             error_message=summary,

--- a/server/sync/tools.py
+++ b/server/sync/tools.py
@@ -103,6 +103,45 @@ async def _get_show_season_ids(show_id: str) -> list[int]:
     return [s["ids"]["trakt"] for s in seasons if s["number"] > 0]
 
 
+def _resolve_show_id(item: TraktHistoryItem) -> str | None:
+    """Return the item's Trakt ID, falling back to its slug, else None."""
+    if not item.ids:
+        return None
+    if item.ids.trakt:
+        return str(item.ids.trakt)
+    return item.ids.slug
+
+
+async def _send_show_as_single(
+    item: TraktHistoryItem,
+    client_method: Callable[[TraktHistoryRequest], Awaitable[HistorySummary | str]],
+    show_id: str | None,
+    operation: str,
+    combined: HistorySummary,
+    *,
+    suppress_cause: bool = False,
+) -> None:
+    """Send a single show item as its own history request and aggregate the result.
+
+    Raises an MCPError if the API returns a string error. ``suppress_cause``
+    raises with ``from None`` so an in-flight ``except`` doesn't chain its
+    caught exception onto the user-facing error.
+    """
+    request = TraktHistoryRequest(shows=[item])
+    result = await client_method(request)
+    if isinstance(result, str):
+        error = ToolErrors.handle_api_string_error(
+            resource_type="sync_history_show",
+            resource_id=show_id or "unknown",
+            error_message=result,
+            operation=operation,
+        )
+        if suppress_cause:
+            raise error from None
+        raise error
+    _aggregate_summary(combined, result, operation)
+
+
 async def _batch_show_history_op(
     client_method: Callable[[TraktHistoryRequest], Awaitable[HistorySummary | str]],
     show_items: list[TraktHistoryItem],
@@ -124,22 +163,12 @@ async def _batch_show_history_op(
     combined = HistorySummary()
 
     for item in show_items:
-        show_id = str(item.ids.trakt) if item.ids and item.ids.trakt else None
-        if show_id is None and item.ids and item.ids.slug:
-            show_id = item.ids.slug
+        show_id = _resolve_show_id(item)
 
         if show_id is None:
-            # No resolvable ID — send the show item directly
-            request = TraktHistoryRequest(shows=[item])
-            result = await client_method(request)
-            if isinstance(result, str):
-                raise ToolErrors.handle_api_string_error(
-                    resource_type="sync_history_show",
-                    resource_id="unknown",
-                    error_message=result,
-                    operation=operation,
-                )
-            _aggregate_summary(combined, result, operation)
+            await _send_show_as_single(
+                item, client_method, show_id, operation, combined
+            )
             continue
 
         try:
@@ -149,16 +178,14 @@ async def _batch_show_history_op(
                 "Failed to fetch seasons for show %s, sending as single request",
                 show_id,
             )
-            request = TraktHistoryRequest(shows=[item])
-            result = await client_method(request)
-            if isinstance(result, str):
-                raise ToolErrors.handle_api_string_error(
-                    resource_type="sync_history_show",
-                    resource_id=show_id,
-                    error_message=result,
-                    operation=operation,
-                ) from None
-            _aggregate_summary(combined, result, operation)
+            await _send_show_as_single(
+                item,
+                client_method,
+                show_id,
+                operation,
+                combined,
+                suppress_cause=True,
+            )
             continue
 
         if not season_ids:
@@ -166,16 +193,9 @@ async def _batch_show_history_op(
                 "No seasons found for show %s, sending as single request",
                 show_id,
             )
-            request = TraktHistoryRequest(shows=[item])
-            result = await client_method(request)
-            if isinstance(result, str):
-                raise ToolErrors.handle_api_string_error(
-                    resource_type="sync_history_show",
-                    resource_id=show_id,
-                    error_message=result,
-                    operation=operation,
-                )
-            _aggregate_summary(combined, result, operation)
+            await _send_show_as_single(
+                item, client_method, show_id, operation, combined
+            )
             continue
 
         # Process seasons sequentially to avoid Trakt API rate-limit pressure

--- a/server/user/resources.py
+++ b/server/user/resources.py
@@ -9,7 +9,7 @@ from client.pool import get_client
 from client.user import UserClient
 from config.mcp.resources import MCP_RESOURCES
 from models.formatters.user import UserFormatters
-from server.base import BaseToolErrorMixin
+from server.base import ToolErrors
 from utils.api.errors import handle_api_errors_func
 
 # Type alias for resource handlers
@@ -35,7 +35,7 @@ async def get_user_watched_shows() -> str:
 
     shows = await client.get_user_watched_shows()
     if isinstance(shows, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="user_watched_shows",
             resource_id="authenticated_user",
             error_message=shows,
@@ -63,7 +63,7 @@ async def get_user_watched_movies() -> str:
 
     movies = await client.get_user_watched_movies()
     if isinstance(movies, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type="user_watched_movies",
             resource_id="authenticated_user",
             error_message=movies,

--- a/server/user/tools.py
+++ b/server/user/tools.py
@@ -12,7 +12,7 @@ from config.api import effective_limit
 from config.auth import AUTH_VERIFICATION_URL
 from config.mcp.descriptions import USER_LIMIT_DESCRIPTION
 from models.formatters.user import UserFormatters
-from server.base import BaseToolErrorMixin
+from server.base import ToolErrors
 from utils.api.error_types import AuthenticationRequiredError
 
 # Type aliases for user tools
@@ -47,7 +47,7 @@ def _validate_and_normalize_limit(value: int | None, *, operation: str) -> int:
             f"Invalid parameters for {operation.replace('_', ' ')}: "
             + "; ".join(field_messages)
         )
-        raise BaseToolErrorMixin.handle_validation_error(
+        raise ToolErrors.handle_validation_error(
             summary_message,
             validation_errors=validation_errors,
             operation=f"{operation}_validation",
@@ -88,7 +88,7 @@ async def _fetch_user_items(
         )
     items = await fetcher()
     if isinstance(items, str):
-        raise BaseToolErrorMixin.handle_api_string_error(
+        raise ToolErrors.handle_api_string_error(
             resource_type=operation,
             resource_id="authenticated_user",
             error_message=items,
@@ -170,7 +170,7 @@ def register_user_tools(mcp: FastMCP) -> tuple[ToolHandler, ToolHandler]:
             "Requires OAuth authentication."
         ),
     )
-    @BaseToolErrorMixin.with_error_handling(
+    @ToolErrors.with_error_handling(
         operation="fetch_user_watched_shows_tool",
         tool="fetch_user_watched_shows",
     )
@@ -196,7 +196,7 @@ def register_user_tools(mcp: FastMCP) -> tuple[ToolHandler, ToolHandler]:
             "Requires OAuth authentication."
         ),
     )
-    @BaseToolErrorMixin.with_error_handling(
+    @ToolErrors.with_error_handling(
         operation="fetch_user_watched_movies_tool",
         tool="fetch_user_watched_movies",
     )

--- a/server/user/tools.py
+++ b/server/user/tools.py
@@ -11,7 +11,6 @@ from client.user.client import UserClient
 from config.api import effective_limit
 from config.auth import AUTH_VERIFICATION_URL
 from config.mcp.descriptions import USER_LIMIT_DESCRIPTION
-from config.mcp.tools import TOOL_NAMES
 from models.formatters.user import UserFormatters
 from server.base import BaseToolErrorMixin
 from utils.api.error_types import AuthenticationRequiredError
@@ -159,7 +158,7 @@ def register_user_tools(mcp: FastMCP) -> tuple[ToolHandler, ToolHandler]:
     """
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_user_watched_shows"],
+        name="fetch_user_watched_shows",
         description=(
             "Fetch list of TV shows the user has watched, "
             "sorted by most recently watched. "
@@ -173,7 +172,7 @@ def register_user_tools(mcp: FastMCP) -> tuple[ToolHandler, ToolHandler]:
     )
     @BaseToolErrorMixin.with_error_handling(
         operation="fetch_user_watched_shows_tool",
-        tool=TOOL_NAMES["fetch_user_watched_shows"],
+        tool="fetch_user_watched_shows",
     )
     async def fetch_user_watched_shows_tool(
         limit: Annotated[
@@ -185,7 +184,7 @@ def register_user_tools(mcp: FastMCP) -> tuple[ToolHandler, ToolHandler]:
         return await fetch_user_watched_shows(limit)
 
     @mcp.tool(
-        name=TOOL_NAMES["fetch_user_watched_movies"],
+        name="fetch_user_watched_movies",
         description=(
             "Fetch list of movies the user has watched, "
             "sorted by most recently watched. "
@@ -199,7 +198,7 @@ def register_user_tools(mcp: FastMCP) -> tuple[ToolHandler, ToolHandler]:
     )
     @BaseToolErrorMixin.with_error_handling(
         operation="fetch_user_watched_movies_tool",
-        tool=TOOL_NAMES["fetch_user_watched_movies"],
+        tool="fetch_user_watched_movies",
     )
     async def fetch_user_watched_movies_tool(
         limit: Annotated[

--- a/tests/config/mcp/test_mcp_tools.py
+++ b/tests/config/mcp/test_mcp_tools.py
@@ -1,14 +1,29 @@
 """Tests for MCP tools module."""
 
-from config.mcp.tools import TOOL_NAMES
+from config.mcp.tools import (
+    AUTH_TOOLS,
+    CHECKIN_TOOLS,
+    COMMENT_TOOLS,
+    EPISODE_TOOLS,
+    MOVIE_TOOLS,
+    PEOPLE_TOOLS,
+    PROGRESS_TOOLS,
+    RECOMMENDATIONS_TOOLS,
+    SEARCH_TOOLS,
+    SEASON_TOOLS,
+    SHOW_TOOLS,
+    SYNC_TOOLS,
+    TOOL_NAMES,
+    USER_TOOLS,
+)
 
 
 class TestToolNames:
-    """Test TOOL_NAMES dictionary structure and contents."""
+    """Test TOOL_NAMES frozenset structure and contents."""
 
-    def test_tool_names_is_dict(self) -> None:
-        """Test TOOL_NAMES is a dictionary."""
-        assert isinstance(TOOL_NAMES, dict)
+    def test_tool_names_is_frozenset(self) -> None:
+        """Test TOOL_NAMES is a non-empty frozenset."""
+        assert isinstance(TOOL_NAMES, frozenset)
         assert len(TOOL_NAMES) > 0
 
     def test_show_tools_exist(self) -> None:
@@ -23,7 +38,6 @@ class TestToolNames:
         ]
         for tool in show_tools:
             assert tool in TOOL_NAMES
-            assert isinstance(TOOL_NAMES[tool], str)
 
     def test_movie_tools_exist(self) -> None:
         """Test movie-related tools are present."""
@@ -37,7 +51,6 @@ class TestToolNames:
         ]
         for tool in movie_tools:
             assert tool in TOOL_NAMES
-            assert isinstance(TOOL_NAMES[tool], str)
 
     def test_auth_tools_exist(self) -> None:
         """Test authentication tools are present."""
@@ -48,7 +61,6 @@ class TestToolNames:
         ]
         for tool in auth_tools:
             assert tool in TOOL_NAMES
-            assert isinstance(TOOL_NAMES[tool], str)
 
     def test_user_tools_exist(self) -> None:
         """Test user-specific tools are present."""
@@ -59,7 +71,6 @@ class TestToolNames:
         ]
         for tool in user_tools:
             assert tool in TOOL_NAMES
-            assert isinstance(TOOL_NAMES[tool], str)
 
     def test_comment_tools_exist(self) -> None:
         """Test comment tools are present."""
@@ -73,7 +84,6 @@ class TestToolNames:
         ]
         for tool in comment_tools:
             assert tool in TOOL_NAMES
-            assert isinstance(TOOL_NAMES[tool], str)
 
     def test_rating_tools_exist(self) -> None:
         """Test rating tools are present."""
@@ -83,7 +93,6 @@ class TestToolNames:
         ]
         for tool in rating_tools:
             assert tool in TOOL_NAMES
-            assert isinstance(TOOL_NAMES[tool], str)
 
     def test_search_tools_exist(self) -> None:
         """Test search tools are present."""
@@ -93,22 +102,14 @@ class TestToolNames:
         ]
         for tool in search_tools:
             assert tool in TOOL_NAMES
-            assert isinstance(TOOL_NAMES[tool], str)
-
-    def test_tool_names_match_keys(self) -> None:
-        """Test tool names match their dictionary keys."""
-        for key, value in TOOL_NAMES.items():
-            assert key == value, f"Tool name key {key} should match value {value}"
 
     def test_tool_naming_conventions(self) -> None:
         """Test tool names follow consistent naming conventions."""
         for tool_name in TOOL_NAMES:
-            # Should use lowercase and underscores
             assert tool_name.islower(), f"Tool name {tool_name} should be lowercase"
             assert " " not in tool_name, (
                 f"Tool name {tool_name} should not contain spaces"
             )
-            # Should not start or end with underscore
             assert not tool_name.startswith("_"), (
                 f"Tool name {tool_name} should not start with underscore"
             )
@@ -126,37 +127,58 @@ class TestToolNames:
 
     def test_tool_categories_consistency(self) -> None:
         """Test tool names are consistent within categories."""
-        # Show tools should contain 'shows'
         show_tools = [
             k for k in TOOL_NAMES if "show" in k and not k.startswith("checkin")
         ]
         for tool in show_tools:
             assert "show" in tool, f"Show tool {tool} should contain 'show'"
 
-        # Movie tools should contain 'movies'
         movie_tools = [k for k in TOOL_NAMES if "movie" in k]
         for tool in movie_tools:
             assert "movie" in tool, f"Movie tool {tool} should contain 'movie'"
 
-        # Auth tools should contain 'auth'
         auth_tools = [k for k in TOOL_NAMES if "auth" in k]
         for tool in auth_tools:
             assert "auth" in tool, f"Auth tool {tool} should contain 'auth'"
 
-    def test_no_duplicate_tool_names(self) -> None:
-        """Test there are no duplicate tool names."""
-        tool_names = list(TOOL_NAMES.values())
-        unique_names = set(tool_names)
-        assert len(unique_names) == len(tool_names), "All tool names should be unique"
+    def test_domain_sets_are_disjoint(self) -> None:
+        """Each tool should belong to exactly one domain set."""
+        domain_sets = {
+            "SHOW_TOOLS": SHOW_TOOLS,
+            "MOVIE_TOOLS": MOVIE_TOOLS,
+            "PEOPLE_TOOLS": PEOPLE_TOOLS,
+            "AUTH_TOOLS": AUTH_TOOLS,
+            "USER_TOOLS": USER_TOOLS,
+            "CHECKIN_TOOLS": CHECKIN_TOOLS,
+            "COMMENT_TOOLS": COMMENT_TOOLS,
+            "EPISODE_TOOLS": EPISODE_TOOLS,
+            "PROGRESS_TOOLS": PROGRESS_TOOLS,
+            "RECOMMENDATIONS_TOOLS": RECOMMENDATIONS_TOOLS,
+            "SEARCH_TOOLS": SEARCH_TOOLS,
+            "SEASON_TOOLS": SEASON_TOOLS,
+            "SYNC_TOOLS": SYNC_TOOLS,
+        }
+        names = list(domain_sets)
+        for i, a_name in enumerate(names):
+            for b_name in names[i + 1 :]:
+                overlap = domain_sets[a_name] & domain_sets[b_name]
+                assert not overlap, f"{a_name} and {b_name} share tool names: {overlap}"
 
-    def test_all_values_are_strings(self) -> None:
-        """Test all tool names are strings."""
-        for key, value in TOOL_NAMES.items():
-            assert isinstance(value, str), (
-                f"Tool {key} name should be string, got {type(value)}"
-            )
-
-    def test_no_empty_values(self) -> None:
-        """Test no tool names are empty."""
-        for key, value in TOOL_NAMES.items():
-            assert value, f"Tool {key} name should not be empty"
+    def test_tool_names_equals_union_of_domain_sets(self) -> None:
+        """TOOL_NAMES should be the exact union of every domain frozenset."""
+        union = (
+            SHOW_TOOLS
+            | MOVIE_TOOLS
+            | PEOPLE_TOOLS
+            | AUTH_TOOLS
+            | USER_TOOLS
+            | CHECKIN_TOOLS
+            | COMMENT_TOOLS
+            | EPISODE_TOOLS
+            | PROGRESS_TOOLS
+            | RECOMMENDATIONS_TOOLS
+            | SEARCH_TOOLS
+            | SEASON_TOOLS
+            | SYNC_TOOLS
+        )
+        assert union == TOOL_NAMES

--- a/tests/config/test_resources.py
+++ b/tests/config/test_resources.py
@@ -184,11 +184,11 @@ class TestResourceUriFormats:
 
 
 class TestToolNames:
-    """Test TOOL_NAMES dictionary structure and contents."""
+    """Test TOOL_NAMES frozenset structure and contents."""
 
-    def test_tool_names_is_dict(self) -> None:
-        """Test TOOL_NAMES is a dictionary."""
-        assert isinstance(TOOL_NAMES, dict)
+    def test_tool_names_is_frozenset(self) -> None:
+        """Test TOOL_NAMES is a non-empty frozenset."""
+        assert isinstance(TOOL_NAMES, frozenset)
         assert len(TOOL_NAMES) > 0
 
     def test_show_tools_exist(self) -> None:
@@ -202,7 +202,6 @@ class TestToolNames:
         ]
         for tool in show_tools:
             assert tool in TOOL_NAMES
-            assert isinstance(TOOL_NAMES[tool], str)
 
     def test_movie_tools_exist(self) -> None:
         """Test movie-related tools are present."""
@@ -215,7 +214,6 @@ class TestToolNames:
         ]
         for tool in movie_tools:
             assert tool in TOOL_NAMES
-            assert isinstance(TOOL_NAMES[tool], str)
 
     def test_auth_tools_exist(self) -> None:
         """Test authentication tools are present."""
@@ -226,7 +224,6 @@ class TestToolNames:
         ]
         for tool in auth_tools:
             assert tool in TOOL_NAMES
-            assert isinstance(TOOL_NAMES[tool], str)
 
     def test_user_tools_exist(self) -> None:
         """Test user-specific tools are present."""
@@ -237,7 +234,6 @@ class TestToolNames:
         ]
         for tool in user_tools:
             assert tool in TOOL_NAMES
-            assert isinstance(TOOL_NAMES[tool], str)
 
     def test_comment_tools_exist(self) -> None:
         """Test comment tools are present."""
@@ -251,7 +247,6 @@ class TestToolNames:
         ]
         for tool in comment_tools:
             assert tool in TOOL_NAMES
-            assert isinstance(TOOL_NAMES[tool], str)
 
     def test_rating_tools_exist(self) -> None:
         """Test rating tools are present."""
@@ -261,7 +256,6 @@ class TestToolNames:
         ]
         for tool in rating_tools:
             assert tool in TOOL_NAMES
-            assert isinstance(TOOL_NAMES[tool], str)
 
     def test_search_tools_exist(self) -> None:
         """Test search tools are present."""
@@ -271,16 +265,10 @@ class TestToolNames:
         ]
         for tool in search_tools:
             assert tool in TOOL_NAMES
-            assert isinstance(TOOL_NAMES[tool], str)
 
 
 class TestToolNamingConsistency:
     """Test tool naming consistency and conventions."""
-
-    def test_tool_names_match_keys(self) -> None:
-        """Test tool names match their dictionary keys."""
-        for key, value in TOOL_NAMES.items():
-            assert key == value, f"Tool name key {key} should match value {value}"
 
     def test_tool_naming_conventions(self) -> None:
         """Test tool names follow consistent naming conventions."""
@@ -336,12 +324,6 @@ class TestResourcesIntegration:
         # Most URIs should be unique (some aliases may exist)
         assert len(unique_uris) >= len(uris) * 0.9  # At least 90% should be unique
 
-    def test_no_duplicate_tool_names(self) -> None:
-        """Test there are no duplicate tool names."""
-        tool_names = list(TOOL_NAMES.values())
-        unique_names = set(tool_names)
-        assert len(unique_names) == len(tool_names), "All tool names should be unique"
-
     def test_resource_tool_correlation(self) -> None:
         """Test that resources and tools have logical correlation."""
         # For each show resource, there should be a corresponding tool
@@ -363,25 +345,21 @@ class TestResourcesIntegration:
             "Should have tools for most movie resources"
         )
 
-    def test_all_values_are_strings(self) -> None:
-        """Test all resource URIs and tool names are strings."""
+    def test_resources_all_values_are_strings(self) -> None:
+        """Test all resource URIs are non-empty strings."""
         for key, value in MCP_RESOURCES.items():
             assert isinstance(value, str), (
                 f"Resource {key} URI should be string, got {type(value)}"
             )
-
-        for key, value in TOOL_NAMES.items():
-            assert isinstance(value, str), (
-                f"Tool {key} name should be string, got {type(value)}"
-            )
-
-    def test_no_empty_values(self) -> None:
-        """Test no resource URIs or tool names are empty."""
-        for key, value in MCP_RESOURCES.items():
             assert value, f"Resource {key} URI should not be empty"
 
-        for key, value in TOOL_NAMES.items():
-            assert value, f"Tool {key} name should not be empty"
+    def test_tool_names_all_non_empty_strings(self) -> None:
+        """Test all tool names are non-empty strings."""
+        for tool_name in TOOL_NAMES:
+            assert isinstance(tool_name, str), (
+                f"Tool name should be string, got {type(tool_name)}"
+            )
+            assert tool_name, "Tool name should not be empty"
 
     def test_mcp_config_matches_domain_modules(self) -> None:
         """Test that MCP configs from main config match domain-specific modules."""
@@ -400,6 +378,5 @@ class TestResourcesIntegration:
             assert key in MCP_RESOURCES, f"Resource {key} missing from main config"
             assert MCP_RESOURCES[key] == value, f"Resource {key} value mismatch"
 
-        for key, value in TOOL_NAMES_DOMAIN.items():
-            assert key in TOOL_NAMES, f"Tool {key} missing from main config"
-            assert TOOL_NAMES[key] == value, f"Tool {key} value mismatch"
+        for tool in TOOL_NAMES_DOMAIN:
+            assert tool in TOOL_NAMES, f"Tool {tool} missing from main config"

--- a/tests/integration/test_error_propagation.py
+++ b/tests/integration/test_error_propagation.py
@@ -87,11 +87,9 @@ class TestErrorPropagationThroughStack:
         """Test 400 Bad Request error propagation from Client to Tool to MCP."""
         # Set up request context
         context = (
-            RequestContext()
+            RequestContext(parameters={"query": "test"})
             .with_endpoint("/shows/search", "GET")
             .with_resource("show", "test-show")
-            .with_parameters(query="test")
-            .with_user("test_user")
         )
         set_current_context(context)
 
@@ -373,11 +371,9 @@ class TestErrorContextPreservation:
         """Test that full request context is preserved in error responses."""
         # Set up comprehensive context
         context = (
-            RequestContext()
+            RequestContext(parameters={"limit": 10, "extended": "full"})
             .with_endpoint("/shows/breaking-bad/ratings", "GET")
             .with_resource("show", "breaking-bad")
-            .with_parameters(limit=10, extended="full")
-            .with_user("test_user_123")
         )
         set_current_context(context)
 
@@ -421,7 +417,7 @@ class TestErrorContextPreservation:
     )
     async def test_parameter_context_in_validation_errors(self):
         """Test that parameter context is preserved in validation errors."""
-        context = RequestContext().with_parameters(show_id="", season=0, episode=-1)
+        context = RequestContext(parameters={"show_id": "", "season": 0, "episode": -1})
         set_current_context(context)
 
         # Test parameter validation error

--- a/tests/integration/test_error_propagation.py
+++ b/tests/integration/test_error_propagation.py
@@ -531,11 +531,11 @@ class TestEdgeCasesAndErrorScenarios:
     @pytest.mark.asyncio
     async def test_missing_required_parameters_validation(self):
         """Test validation of missing required parameters."""
-        from server.base.error_mixin import BaseToolErrorMixin
+        from server.base.error_mixin import ToolErrors
 
         # Test the validation mixin directly
         with pytest.raises(InvalidParamsError) as exc_info:
-            BaseToolErrorMixin.validate_required_params(
+            ToolErrors.validate_required_params(
                 show_id=None,
                 movie_id="",
                 query="   ",  # Whitespace only
@@ -555,11 +555,11 @@ class TestEdgeCasesAndErrorScenarios:
     @pytest.mark.asyncio
     async def test_either_or_parameter_validation(self):
         """Test validation of either/or parameter requirements."""
-        from server.base.error_mixin import BaseToolErrorMixin
+        from server.base.error_mixin import ToolErrors
 
         # Test successful validation - one valid set provided
         try:
-            BaseToolErrorMixin.validate_either_or_params(
+            ToolErrors.validate_either_or_params(
                 [("show_id",), ("show_title", "show_year")],
                 show_id="breaking-bad",
                 show_title="",
@@ -572,7 +572,7 @@ class TestEdgeCasesAndErrorScenarios:
 
         # Test failed validation - no valid sets provided
         with pytest.raises(InvalidParamsError) as exc_info:
-            BaseToolErrorMixin.validate_either_or_params(
+            ToolErrors.validate_either_or_params(
                 [("show_id",), ("show_title", "show_year")],
                 show_id="",
                 show_title="",

--- a/tests/server/base/test_error_mixin.py
+++ b/tests/server/base/test_error_mixin.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 from server.base.error_mixin import (
-    BaseToolErrorMixin,
+    ToolErrors,
     is_sensitive_key,
     sanitize_args,
     sanitize_kwargs,
@@ -157,7 +157,7 @@ class TestErrorHandlingDecorator:
     async def test_with_error_handling_sanitizes_sensitive_args(self) -> None:
         """Test that sensitive args are sanitized in error data."""
 
-        @BaseToolErrorMixin.with_error_handling("test_operation")
+        @ToolErrors.with_error_handling("test_operation")
         async def failing_function(token: str, user_id: str) -> None:
             raise ValueError("Test error")
 
@@ -177,7 +177,7 @@ class TestErrorHandlingDecorator:
     async def test_with_error_handling_sanitizes_sensitive_kwargs(self) -> None:
         """Test that sensitive kwargs are sanitized in error data."""
 
-        @BaseToolErrorMixin.with_error_handling("test_operation")
+        @ToolErrors.with_error_handling("test_operation")
         async def failing_function(**kwargs: Any) -> None:
             raise ValueError("Test error")
 
@@ -206,7 +206,7 @@ class TestErrorHandlingDecorator:
     async def test_with_error_handling_preserves_non_sensitive_data(self) -> None:
         """Test that non-sensitive data is preserved in error data."""
 
-        @BaseToolErrorMixin.with_error_handling("test_operation")
+        @ToolErrors.with_error_handling("test_operation")
         async def failing_function(show_id: str, season: int, **kwargs: Any) -> None:
             raise ValueError("Test error")
 
@@ -233,7 +233,7 @@ class TestErrorHandlingDecorator:
     async def test_with_error_handling_returns_friendly_auth_message(self) -> None:
         """Test AuthenticationRequiredError returns friendly message, does not raise."""
 
-        @BaseToolErrorMixin.with_error_handling("test_operation")
+        @ToolErrors.with_error_handling("test_operation")
         async def auth_failing_function() -> str:
             raise AuthenticationRequiredError("access shows")
 

--- a/tests/utils/api/test_request_context.py
+++ b/tests/utils/api/test_request_context.py
@@ -29,7 +29,6 @@ def test_request_context_creation():
     assert context.method is None
     assert context.resource_type is None
     assert context.resource_id is None
-    assert context.user_id is None
     assert context.parameters == {}
 
     # Check start_time is set
@@ -71,45 +70,12 @@ def test_request_context_with_resource():
     assert new_context.correlation_id == context.correlation_id
 
 
-def test_request_context_with_parameters():
-    """Test adding parameters to context."""
-    context = RequestContext()
-    new_context = context.with_parameters(limit=10, period="weekly")
-
-    # Original context unchanged
-    assert context.parameters == {}
-
-    # New context has parameters
-    assert new_context.parameters == {"limit": 10, "period": "weekly"}
-
-    # Correlation ID is preserved
-    assert new_context.correlation_id == context.correlation_id
-
-
-def test_request_context_with_user():
-    """Test adding user information to context."""
-    context = RequestContext()
-    new_context = context.with_user("user123")
-
-    # Original context unchanged
-    assert context.user_id is None
-
-    # New context has user info
-    assert new_context.user_id == "user123"
-
-    # Correlation ID is preserved
-    assert new_context.correlation_id == context.correlation_id
-
-
 def test_request_context_chaining():
     """Test chaining context modifications."""
     context = RequestContext()
 
-    final_context = (
-        context.with_endpoint("/shows/search", "GET")
-        .with_resource("show", "breaking-bad")
-        .with_parameters(query="breaking")
-        .with_user("user123")
+    final_context = context.with_endpoint("/shows/search", "GET").with_resource(
+        "show", "breaking-bad"
     )
 
     # Final context has all information
@@ -117,8 +83,6 @@ def test_request_context_chaining():
     assert final_context.method == "GET"
     assert final_context.resource_type == "show"
     assert final_context.resource_id == "breaking-bad"
-    assert final_context.parameters == {"query": "breaking"}
-    assert final_context.user_id == "user123"
 
     # Correlation ID is preserved
     assert final_context.correlation_id == context.correlation_id
@@ -139,11 +103,9 @@ def test_request_context_elapsed_time():
 def test_request_context_to_dict():
     """Test context serialization to dictionary."""
     context = (
-        RequestContext()
+        RequestContext(parameters={"limit": 10})
         .with_endpoint("/shows/trending", "GET")
         .with_resource("show", "test-show")
-        .with_parameters(limit=10)
-        .with_user("user123")
     )
 
     context_dict = context.to_dict()
@@ -209,10 +171,9 @@ def test_add_context_to_error_data_with_context():
     """Test adding context to error data when context exists."""
     # Set up context
     context = (
-        RequestContext()
+        RequestContext(parameters={"limit": 10})
         .with_endpoint("/shows/trending", "GET")
         .with_resource("show", "test-show")
-        .with_parameters(limit=10)
     )
     set_current_context(context)
 

--- a/tests/utils/api/test_structured_logging.py
+++ b/tests/utils/api/test_structured_logging.py
@@ -33,7 +33,6 @@ def test_context_filter_with_context():
         RequestContext()
         .with_endpoint("/test/endpoint", "GET")
         .with_resource("test", "test-id")
-        .with_user("user123")
     )
     set_current_context(context)
 

--- a/utils/api/request_context.py
+++ b/utils/api/request_context.py
@@ -26,7 +26,6 @@ class RequestContext:
     method: str | None = None
     resource_type: str | None = None
     resource_id: str | None = None
-    user_id: str | None = None
     parameters: dict[str, Any] = field(default_factory=lambda: {})
     start_time: float = field(default_factory=time.time)
 
@@ -53,30 +52,6 @@ class RequestContext:
             New RequestContext with resource information
         """
         return replace(self, resource_type=resource_type, resource_id=resource_id)
-
-    def with_parameters(self, **params: Any) -> RequestContext:
-        """Create a new context with additional parameters.
-
-        Args:
-            **params: Additional parameters to add to context
-
-        Returns:
-            New RequestContext with merged parameters
-        """
-        new_params = self.parameters.copy()
-        new_params.update(params)
-        return replace(self, parameters=new_params)
-
-    def with_user(self, user_id: str) -> RequestContext:
-        """Create a new context with user information.
-
-        Args:
-            user_id: ID of the authenticated user
-
-        Returns:
-            New RequestContext with user information
-        """
-        return replace(self, user_id=user_id)
 
     def elapsed_time(self) -> float:
         """Get elapsed time since request started."""


### PR DESCRIPTION
## Summary

Refactor that remove dead code, collapse duplicate patterns, and tighten typing — without altering any tool's runtime behavior or MCP surface.

1. Inline single-use TypeGuard
- Inline `_is_list_of_dicts` into `_is_list_response` (`client/base.py`) — single-use helper.
- Add `.playwright-mcp/` to `.gitignore`.
- Note: M3 (inlining `_is_instance_of` in `client/pool.py`) was attempted and reverted — pyright 1.1.407 doesn't narrow `isinstance(x, cls)` when `cls` is a bound TypeVar.

2. Dedupe cast section formatter and drop recommendation Protocol
- Lift `_format_cast_section` to `models/formatters/utils.py` as `format_cast_section` with an `include_episode_count` flag. Three near-identical private wrappers removed across shows / seasons / episodes formatters.
- Replace `_RecommendationItem` Protocol with the concrete `TraktRecommendedMovie | TraktRecommendedShow` union.

3. Replace `TOOL_NAMES` echo-dict with frozenset and string literals
- Per-domain `TOOL_NAMES` dicts in `config/mcp/tools/*.py` mapped each key to itself (`"fetch_x" -> "fetch_x"`), making `TOOL_NAMES["fetch_x"]` semantically equivalent to the literal `"fetch_x"`.
- Per-domain dicts → `Final[frozenset[str]]` of tool names.
- Top-level `TOOL_NAMES` is the union of every domain set.
- All `@mcp.tool(name=TOOL_NAMES["fetch_x"])` and direct-import variants → `@mcp.tool(name="fetch_x")`.
- Tests drop dict-shape assertions and add invariants: domain sets are disjoint and equal their union.

4. Rename `BaseToolErrorMixin` → `ToolErrors`
- The class is a static namespace (no state, every member is `@staticmethod`/`@classmethod`, no class has ever inherited from it). "Mixin" misled.
- Pure rename; no behavior change.

5. Extract `_resolve_show_id` and `_send_show_as_single` from batch history op
- `_batch_show_history_op` (`server/sync/tools.py`) had three near-identical fallback blocks (no resolvable ID / season fetch failed / no seasons found) that each built a single-show `TraktHistoryRequest`, called the client, dispatched string-errors via `ToolErrors.handle_api_string_error`, and aggregated.
- `_resolve_show_id(item)` pulls trakt-id / slug fallback out of the loop.
- `_send_show_as_single(...)` consolidates the three fallback recipes; `suppress_cause=True` preserves `raise ... from None` on the season-fetch branch.
- 65 sync tests green.

6. Drop unused `RequestContext.user_id` field and builders
- `RequestContext.with_parameters`, `RequestContext.with_user`, and `user_id` have zero production callers. The field never appeared in `to_dict()` output.
- Tests that existed only to exercise these APIs are removed; tests that used them as builders are rewritten to construct contexts directly.

7. Type `response_type.model_validate` via the `PydanticModel` Protocol
- `response_type` in `client/base.py` (`_make_typed_request`, `_make_typed_list_request`, `_make_paginated_request`, `_post_typed_request`) mixes Pydantic `BaseModel`s and `TypedDict`s. `_is_pydantic_model` returns `TypeGuard[type[PydanticModel]]` so pyright narrows the `response_type.model_validate(...)` call sites — the Protocol is the type-level branch that mirrors the runtime guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified tool configuration and standardized tool-name sets for more consistent behavior
  * Centralized and unified error-handling utilities across services
  * Consolidated people/cast/crew formatting into shared formatters for consistent output

* **Documentation**
  * Updated API error-handling guidance to reference the current helper

* **Chores**
  * Project ignore rules updated (added CI/playwright dir; removed some local note patterns)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->