### PR TITLE
feat: bump fastmcp to 3.x and surface server version on the wire

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,19 +110,18 @@ pytest
 pytest tests/client/auth/ -v  # Focused testing
 
 # Code quality (zero tolerance for errors/warnings)
-ruff check --fix    # Linting  
+ruff check --fix    # Linting
 ruff format         # Formatting
 pyright             # Type checking
 pip-audit           # Security scanning
-npx @modelcontextprotocol/inspector --cli python server.py --method tools/list    # MCP validation
+fastmcp inspect server.py                                # MCP validation (text summary)
 
 # MCP server
-python server.py                                                        # Direct run
-mcp dev server.py                                                      # Development mode
-npx @modelcontextprotocol/inspector --cli python server.py --method tools/list    # MCP validation (list tools)
-npx @modelcontextprotocol/inspector --cli python server.py --method resources/list # MCP validation (list resources)
-npx @modelcontextprotocol/inspector --cli python server.py --method prompts/list   # MCP validation (list prompts)
-npx @modelcontextprotocol/inspector --cli python server.py --method tools/call     # Call specific tool
+python server.py                                                          # Direct run
+fastmcp dev inspector server.py                                           # Launch in MCP Inspector
+fastmcp inspect server.py --format mcp -o report.json                     # Full MCP-protocol JSON
+fastmcp list server.py --json --resources --prompts                       # List tools/resources/prompts as JSON
+fastmcp call server.py <tool-name> [--args '{"k": "v"}']                  # Invoke a tool
 ```
 
 ## Code Quality Requirements

--- a/README.md
+++ b/README.md
@@ -855,22 +855,28 @@ This project was built using AI-assisted development tools:
 - **[Aider](https://aider.chat/)** - AI pair programming tool for code collaboration
 - **[Claude Code](https://claude.ai/code)** - Claude's dedicated coding interface
 
-### Testing with MCP Inspector
+### Validating with the FastMCP CLI
 
-Validate your MCP server implementation and explore available tools, resources, and prompts.
+Inspect the server and exercise tools directly from the terminal — no Node dependency.
 
 <details>
-<summary><strong>View MCP Inspector commands</strong></summary>
+<summary><strong>View FastMCP CLI commands</strong></summary>
 
 ```bash
-# List available tools
-npx @modelcontextprotocol/inspector --cli python server.py --method tools/list
+# Text summary (tools/resources/prompts counts)
+fastmcp inspect server.py
 
-# List available resources
-npx @modelcontextprotocol/inspector --cli python server.py --method resources/list
+# Full MCP-protocol JSON report
+fastmcp inspect server.py --format mcp -o report.json
 
-# List available prompts
-npx @modelcontextprotocol/inspector --cli python server.py --method prompts/list
+# List tools/resources/prompts as JSON
+fastmcp list server.py --json --resources --prompts
+
+# Invoke a tool
+fastmcp call server.py fetch_trending_shows --args '{"limit": 5}'
+
+# Launch the server inside the MCP Inspector UI
+fastmcp dev inspector server.py
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -893,7 +893,9 @@ This project was built using AI-assisted development tools:
 
 ### Validating with the FastMCP CLI
 
-Inspect the server and exercise tools directly from the terminal — no Node dependency.
+Inspect the server and exercise tools directly from the terminal. The `inspect`,
+`list`, and `call` commands have no Node dependency; `fastmcp dev inspector`
+launches the Node-based MCP Inspector UI via `npx`.
 
 <details>
 <summary><strong>View FastMCP CLI commands</strong></summary>

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Requires Python 3.12 or newer.
    ```bash
    python3 -m venv .venv
    source .venv/bin/activate
-   pip install -e .
+   pip install .
    ```
 
 3. **Set up your environment**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,11 @@ description = "Model Context Protocol server bridging AI models with the Trakt.t
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "python-dotenv>=1.1.1",
+    "python-dotenv>=1.2.2",
     "httpx>=0.27.0",
-    "mcp>=1.10.1",
-    "pydantic==2.11.7",
+    "fastmcp>=3.2.0,<4",
+    "mcp>=1.27.0",
+    "pydantic>=2.13,<3",
 ]
 
 [build-system]

--- a/server.py
+++ b/server.py
@@ -10,6 +10,12 @@ from server.main import mcp  # noqa: E402
 if __name__ == "__main__":
     # Print to stderr to avoid polluting stdout (required for stdio transport)
     print("Starting Trakt MCP server...", file=sys.stderr)
-    print("Run 'mcp dev server.py' to test with the MCP Inspector", file=sys.stderr)
-    print("Run 'mcp install server.py' to install in Claude Desktop", file=sys.stderr)
+    print(
+        "Run 'fastmcp dev inspector server.py' to test in the MCP Inspector",
+        file=sys.stderr,
+    )
+    print(
+        "Run 'fastmcp install server.py' to install in a client",
+        file=sys.stderr,
+    )
     mcp.run()

--- a/server.py
+++ b/server.py
@@ -1,4 +1,6 @@
-from server.main import run
+from server.main import mcp, run
+
+__all__ = ["mcp", "run"]
 
 if __name__ == "__main__":
     run()

--- a/server/auth/resources.py
+++ b/server/auth/resources.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from client.auth import AuthClient
 from client.pool import get_client

--- a/server/auth/tools.py
+++ b/server/auth/tools.py
@@ -5,7 +5,7 @@ import logging
 import time
 from typing import Any, TypedDict
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from client.auth import AuthClient
 from client.pool import get_client

--- a/server/auth/tools.py
+++ b/server/auth/tools.py
@@ -220,8 +220,7 @@ def register_auth_tools(mcp: FastMCP) -> tuple[Any, Any, Any]:
     @mcp.tool(
         name="check_auth_status",
         description="Check the status of an ongoing device authentication flow",
-        annotations=ToolAnnotations(readOnlyHint=True),
-        tags={"read", "auth_flow"},
+        tags={"auth_flow"},
     )
     async def check_auth_status_tool() -> str:
         return await check_auth_status()

--- a/server/auth/tools.py
+++ b/server/auth/tools.py
@@ -6,6 +6,7 @@ import time
 from typing import Any, TypedDict
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from client.auth import AuthClient
 from client.pool import get_client
@@ -211,6 +212,7 @@ def register_auth_tools(mcp: FastMCP) -> tuple[Any, Any, Any]:
     @mcp.tool(
         name="start_device_auth",
         description="Start the device authentication flow with Trakt TV",
+        tags={"auth_flow"},
     )
     async def start_device_auth_tool() -> str:
         return await start_device_auth()
@@ -218,6 +220,8 @@ def register_auth_tools(mcp: FastMCP) -> tuple[Any, Any, Any]:
     @mcp.tool(
         name="check_auth_status",
         description="Check the status of an ongoing device authentication flow",
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read", "auth_flow"},
     )
     async def check_auth_status_tool() -> str:
         return await check_auth_status()
@@ -225,6 +229,8 @@ def register_auth_tools(mcp: FastMCP) -> tuple[Any, Any, Any]:
     @mcp.tool(
         name="clear_auth",
         description="Clear the authentication token and log out of Trakt",
+        annotations=ToolAnnotations(destructiveHint=True),
+        tags={"write", "auth_flow"},
     )
     async def clear_auth_tool() -> str:
         return await clear_auth()

--- a/server/checkin/tools.py
+++ b/server/checkin/tools.py
@@ -4,6 +4,7 @@ import logging
 from typing import Annotated, Any
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from client.checkin.client import CheckinClient
@@ -123,6 +124,8 @@ def register_checkin_tools(mcp: FastMCP) -> Any:
     @mcp.tool(
         name="checkin_to_show",
         description="Check in to a TV show episode you're currently watching on Trakt",
+        annotations=ToolAnnotations(destructiveHint=True),
+        tags={"write", "auth_required"},
     )
     async def checkin_to_show_tool(
         season: Annotated[int, Field(description=SEASON_DESCRIPTION)],

--- a/server/checkin/tools.py
+++ b/server/checkin/tools.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from pydantic import Field
 
 from client.checkin.client import CheckinClient

--- a/server/checkin/tools.py
+++ b/server/checkin/tools.py
@@ -124,7 +124,7 @@ def register_checkin_tools(mcp: FastMCP) -> Any:
     @mcp.tool(
         name="checkin_to_show",
         description="Check in to a TV show episode you're currently watching on Trakt",
-        annotations=ToolAnnotations(destructiveHint=True),
+        annotations=ToolAnnotations(destructiveHint=False),
         tags={"write", "auth_required"},
     )
     async def checkin_to_show_tool(

--- a/server/comments/tools.py
+++ b/server/comments/tools.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable
 from typing import Annotated, Literal, NoReturn, TypedDict
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from pydantic import BaseModel, Field, PositiveInt, ValidationError
 
 from client.comments.details import CommentDetailsClient

--- a/server/comments/tools.py
+++ b/server/comments/tools.py
@@ -4,6 +4,7 @@ from collections.abc import Awaitable, Callable
 from typing import Annotated, Literal, NoReturn, TypedDict
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field, PositiveInt, ValidationError
 
 from client.comments.details import CommentDetailsClient
@@ -596,6 +597,8 @@ def register_comment_tools(
             "Supports optional pagination with 'page' parameter and "
             "safety cap 'max_pages'."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_movie_comments_tool(
         movie_id: Annotated[str, Field(min_length=1, description=MOVIE_ID_DESCRIPTION)],
@@ -624,6 +627,8 @@ def register_comment_tools(
             "Supports optional pagination with 'page' parameter and "
             "safety cap 'max_pages'."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_show_comments_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -652,6 +657,8 @@ def register_comment_tools(
             "Supports optional pagination with 'page' parameter and "
             "safety cap 'max_pages'."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_season_comments_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -681,6 +688,8 @@ def register_comment_tools(
             "Supports optional pagination with 'page' parameter and "
             "safety cap 'max_pages'."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_episode_comments_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -707,6 +716,8 @@ def register_comment_tools(
     @mcp.tool(
         name="fetch_comment",
         description="Fetch a specific comment from Trakt",
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_comment_tool(
         comment_id: Annotated[
@@ -725,6 +736,8 @@ def register_comment_tools(
             "Supports optional pagination with 'page' parameter and "
             "safety cap 'max_pages'."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_comment_replies_tool(
         comment_id: Annotated[

--- a/server/episodes/tools.py
+++ b/server/episodes/tools.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Annotated, Final, Literal, TypeAlias
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from pydantic import Field
 
 from client.episodes.lists import EpisodeListsClient

--- a/server/episodes/tools.py
+++ b/server/episodes/tools.py
@@ -6,6 +6,7 @@ from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Annotated, Final, Literal, TypeAlias
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from client.episodes.lists import EpisodeListsClient
@@ -400,6 +401,8 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch detailed information about a specific TV show episode, "
             "including overview, air date, runtime, and ratings."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_episode_summary_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -413,6 +416,8 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         description=(
             "Fetch ratings and voting statistics for a specific TV show episode."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_episode_ratings_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -427,6 +432,8 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch engagement statistics for a specific TV show episode "
             "including watchers, plays, collectors, and comments."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_episode_stats_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -441,6 +448,8 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch cast and crew for a specific TV show episode, "
             "including character names and episode counts."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_episode_people_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -455,6 +464,8 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch videos (trailers, recaps, etc.) for a specific TV show episode. "
             "Set embed_markdown=False for simple links."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_episode_videos_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -472,6 +483,8 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         description=(
             "Fetch users currently watching a specific TV show episode right now."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_episode_watching_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -485,6 +498,8 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         description=(
             "Fetch translations for a specific TV show episode in different languages."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_episode_translations_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -497,6 +512,8 @@ def register_episode_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
     @mcp.tool(
         name="fetch_episode_lists",
         description="Fetch lists that contain a specific TV show episode.",
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_episode_lists_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],

--- a/server/main.py
+++ b/server/main.py
@@ -90,6 +90,12 @@ mcp = create_server()
 if __name__ == "__main__":
     # Print to stderr to avoid polluting stdout (required for stdio transport)
     print("Starting Trakt MCP server...", file=sys.stderr)
-    print("Run 'mcp dev server.py' to test with the MCP Inspector", file=sys.stderr)
-    print("Run 'mcp install server.py' to install in Claude Desktop", file=sys.stderr)
+    print(
+        "Run 'fastmcp dev inspector server.py' to test in the MCP Inspector",
+        file=sys.stderr,
+    )
+    print(
+        "Run 'fastmcp install server.py' to install in a client",
+        file=sys.stderr,
+    )
     mcp.run()

--- a/server/main.py
+++ b/server/main.py
@@ -8,7 +8,7 @@ from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from typing import Final
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from client.pool import shutdown_clients
 
@@ -66,17 +66,17 @@ async def _lifespan(_mcp: FastMCP) -> AsyncGenerator[None]:
 
 
 def create_server() -> FastMCP:
-    """Create and configure the Trakt MCP server with all modules.
-
-    Returns:
-        Configured FastMCP server instance
-    """
+    """Create and configure the Trakt MCP server with all modules."""
     try:
         version = _pkg_version("trakt-mcp-server")
     except PackageNotFoundError:
         version = "0.0.0+dev"
     logger.info("Starting trakt-mcp-server v%s", version)
-    mcp = FastMCP(name="trakt-mcp-server", lifespan=_lifespan)
+    mcp = FastMCP(
+        name="trakt-mcp-server",
+        version=version,
+        lifespan=_lifespan,
+    )
     for register in REGISTRATIONS:
         register(mcp)
     logger.info("All Trakt MCP modules registered successfully")

--- a/server/movies/resources.py
+++ b/server/movies/resources.py
@@ -7,7 +7,7 @@ from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, TypeAlias
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP
+    from fastmcp import FastMCP
 
     from models.types import MovieResponse
 from pydantic import ValidationError

--- a/server/movies/tools.py
+++ b/server/movies/tools.py
@@ -7,6 +7,7 @@ from collections.abc import Awaitable, Callable
 from typing import Annotated, Literal
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from client.movies.anticipated import AnticipatedMoviesClient
@@ -561,6 +562,8 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch trending movies from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_trending_movies_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -574,6 +577,8 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch popular movies from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_popular_movies_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -587,6 +592,8 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch most favorited movies from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_favorited_movies_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -604,6 +611,8 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch most played movies from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_played_movies_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -621,6 +630,8 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch most watched movies from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_watched_movies_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -638,6 +649,8 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch most anticipated movies from Trakt, sorted by list count. "
             "Use page parameter for paginated results, or omit for all results."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_anticipated_movies_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -651,6 +664,8 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch the top 10 grossing movies in the U.S. box office last weekend. "
             "Updated every Monday morning."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_boxoffice_movies_tool() -> str:
         return await fetch_boxoffice_movies()
@@ -658,6 +673,8 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
     @mcp.tool(
         name="fetch_movie_ratings",
         description="Fetch ratings and voting statistics for a specific movie",
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_movie_ratings_tool(
         movie_id: Annotated[str, Field(min_length=1, description=MOVIE_ID_DESCRIPTION)],
@@ -674,6 +691,8 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "production status, ratings, genres, runtime, certification, and metadata. "
             "Basic mode (extended=false): Returns only title, year, and Trakt ID."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_movie_summary_tool(
         movie_id: Annotated[str, Field(min_length=1, description=MOVIE_ID_DESCRIPTION)],
@@ -690,6 +709,8 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Set embed_markdown=False to return simple links instead of "
             "YouTube iframes."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_movie_videos_tool(
         movie_id: Annotated[str, Field(min_length=1, description=MOVIE_ID_DESCRIPTION)],
@@ -710,6 +731,8 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "based on genres, themes, and viewer patterns. "
             "Use page parameter for paginated results, or omit for all results."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_related_movies_tool(
         movie_id: Annotated[str, Field(min_length=1, description=MOVIE_ID_DESCRIPTION)],
@@ -725,6 +748,8 @@ def register_movie_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Returns cast with character names and crew "
             "grouped by department."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_movie_people_tool(
         movie_id: Annotated[

--- a/server/movies/tools.py
+++ b/server/movies/tools.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Annotated, Literal
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from pydantic import Field
 
 from client.movies.anticipated import AnticipatedMoviesClient

--- a/server/people/tools.py
+++ b/server/people/tools.py
@@ -6,6 +6,7 @@ from collections.abc import Awaitable, Callable
 from typing import Annotated, Final, Literal, TypeAlias
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from client.people.lists import PersonListsClient
@@ -212,6 +213,8 @@ def register_people_tools(
             "birthday, biography, social media. "
             "Basic (extended=false): name and IDs only."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_person_summary_tool(
         person_id: Annotated[
@@ -229,6 +232,8 @@ def register_people_tools(
             "Returns cast roles and crew positions grouped by "
             "department."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_person_movies_tool(
         person_id: Annotated[
@@ -245,6 +250,8 @@ def register_people_tools(
             "Returns cast roles with episode counts and crew "
             "positions grouped by department."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_person_shows_tool(
         person_id: Annotated[
@@ -261,6 +268,8 @@ def register_people_tools(
             "Returns personal or official lists sorted by "
             "popularity, likes, or other criteria."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_person_lists_tool(
         person_id: Annotated[

--- a/server/people/tools.py
+++ b/server/people/tools.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Annotated, Final, Literal, TypeAlias
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from pydantic import Field
 
 from client.people.lists import PersonListsClient

--- a/server/progress/tools.py
+++ b/server/progress/tools.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Annotated, Literal
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from pydantic import BaseModel, Field
 
 from client.pool import get_client

--- a/server/progress/tools.py
+++ b/server/progress/tools.py
@@ -5,6 +5,7 @@ from collections.abc import Awaitable, Callable
 from typing import Annotated, Literal
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 
 from client.pool import get_client
@@ -169,6 +170,8 @@ def register_progress_tools(
             "For listing all watched shows, use fetch_user_watched_shows instead. "
             "Requires OAuth authentication."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read", "auth_required"},
     )
     async def fetch_show_progress_tool(
         show_id: Annotated[str, Field(description=SHOW_ID_DESCRIPTION)],
@@ -200,6 +203,8 @@ def register_progress_tools(
             "that were paused during playback with their progress percentage. "
             "Requires OAuth authentication."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read", "auth_required"},
     )
     async def fetch_playback_progress_tool(
         playback_type: Annotated[
@@ -215,6 +220,8 @@ def register_progress_tools(
             "Remove a paused playback progress item. Use the ID from "
             "fetch_playback_progress results. Requires OAuth authentication."
         ),
+        annotations=ToolAnnotations(destructiveHint=True),
+        tags={"write", "auth_required"},
     )
     async def remove_playback_item_tool(
         playback_id: Annotated[int, Field(description=PLAYBACK_ID_DESCRIPTION)],

--- a/server/prompts/basic.py
+++ b/server/prompts/basic.py
@@ -8,7 +8,6 @@ discovery and search scenarios.
 from fastmcp import FastMCP
 from fastmcp.prompts import Message
 
-
 _DISCOVER_TRENDING_TEXT = (
     "Show me what movies and TV shows are trending on Trakt right now. "
     "Please include both movies and shows, and provide details about "

--- a/server/prompts/basic.py
+++ b/server/prompts/basic.py
@@ -5,20 +5,25 @@ This module provides fundamental conversation prompts for entertainment
 discovery and search scenarios.
 """
 
+from collections.abc import Awaitable, Callable
+from typing import Final
+
 from fastmcp import FastMCP
 from fastmcp.prompts import Message
 
-_DISCOVER_TRENDING_TEXT = (
+_DISCOVER_TRENDING_TEXT: Final[str] = (
     "Show me what movies and TV shows are trending on Trakt right now. "
     "Please include both movies and shows, and provide details about "
     "ratings, genres, and why they're popular."
 )
 
-_SEARCH_ENTERTAINMENT_TEXT = (
+_SEARCH_ENTERTAINMENT_TEXT: Final[str] = (
     "Help me search for a movie or TV show. I'd like to find something "
     "specific by title, and also get recommendations based on what I'm "
     "looking for. What would you like to find?"
 )
+
+BasicPromptHandler = Callable[[], Awaitable[list[Message]]]
 
 
 async def discover_trending() -> list[Message]:
@@ -31,7 +36,9 @@ async def search_entertainment() -> list[Message]:
     return [Message(_SEARCH_ENTERTAINMENT_TEXT)]
 
 
-def register_basic_prompts(mcp: FastMCP) -> tuple[object, object]:
+def register_basic_prompts(
+    mcp: FastMCP,
+) -> tuple[BasicPromptHandler, BasicPromptHandler]:
     """Register basic prompts with the MCP server."""
 
     @mcp.prompt(

--- a/server/prompts/basic.py
+++ b/server/prompts/basic.py
@@ -5,55 +5,41 @@ This module provides fundamental conversation prompts for entertainment
 discovery and search scenarios.
 """
 
-from typing import Any
+from fastmcp import FastMCP
+from fastmcp.prompts import Message
 
-from mcp.server.fastmcp import FastMCP
+
+_DISCOVER_TRENDING_TEXT = (
+    "Show me what movies and TV shows are trending on Trakt right now. "
+    "Please include both movies and shows, and provide details about "
+    "ratings, genres, and why they're popular."
+)
+
+_SEARCH_ENTERTAINMENT_TEXT = (
+    "Help me search for a movie or TV show. I'd like to find something "
+    "specific by title, and also get recommendations based on what I'm "
+    "looking for. What would you like to find?"
+)
 
 
-async def discover_trending() -> list[dict[str, Any]]:
+async def discover_trending() -> list[Message]:
     """Prompt for discovering trending entertainment content."""
-    return [
-        {
-            "role": "user",
-            "content": (
-                "Show me what movies and TV shows are trending on Trakt right now. "
-                "Please include both movies and shows, and provide details about "
-                "ratings, genres, and why they're popular."
-            ),
-        }
-    ]
+    return [Message(_DISCOVER_TRENDING_TEXT)]
 
 
-async def search_entertainment() -> list[dict[str, Any]]:
+async def search_entertainment() -> list[Message]:
     """Prompt for searching entertainment content."""
-    return [
-        {
-            "role": "user",
-            "content": (
-                "Help me search for a movie or TV show. I'd like to find something "
-                "specific by title, and also get recommendations based on what I'm "
-                "looking for. What would you like to find?"
-            ),
-        }
-    ]
+    return [Message(_SEARCH_ENTERTAINMENT_TEXT)]
 
 
-def register_basic_prompts(mcp: FastMCP) -> tuple[Any, Any]:
-    """Register basic prompts with the MCP server.
-
-    Args:
-        mcp: The FastMCP server instance to register prompts with
-
-    Returns:
-        Tuple of registered prompt handlers (for type checker visibility)
-    """
+def register_basic_prompts(mcp: FastMCP) -> tuple[object, object]:
+    """Register basic prompts with the MCP server."""
 
     @mcp.prompt(
         name="discover_trending",
         description="Discover trending movies and TV shows on Trakt",
     )
-    async def discover_trending_prompt() -> list[dict[str, Any]]:
-        """Wrapper for discover_trending prompt."""
+    async def discover_trending_prompt() -> list[Message]:
         return await discover_trending()
 
     @mcp.prompt(
@@ -62,9 +48,7 @@ def register_basic_prompts(mcp: FastMCP) -> tuple[Any, Any]:
             "Search for movies or TV shows by title with personalized recommendations"
         ),
     )
-    async def search_entertainment_prompt() -> list[dict[str, Any]]:
-        """Wrapper for search_entertainment prompt."""
+    async def search_entertainment_prompt() -> list[Message]:
         return await search_entertainment()
 
-    # Return handlers to satisfy type checker
     return (discover_trending_prompt, search_entertainment_prompt)

--- a/server/recommendations/tools.py
+++ b/server/recommendations/tools.py
@@ -312,7 +312,7 @@ def register_recommendation_tools(
             "Hide a movie from future recommendations. Requires OAuth authentication. "
             "Use Trakt ID, slug, or IMDB ID to identify the movie."
         ),
-        annotations=ToolAnnotations(destructiveHint=True),
+        annotations=ToolAnnotations(destructiveHint=False),
         tags={"write", "auth_required"},
     )
     async def hide_movie_recommendation_tool(
@@ -328,7 +328,7 @@ def register_recommendation_tools(
             "Requires OAuth authentication. "
             "Use Trakt ID, slug, or IMDB ID to identify the show."
         ),
-        annotations=ToolAnnotations(destructiveHint=True),
+        annotations=ToolAnnotations(destructiveHint=False),
         tags={"write", "auth_required"},
     )
     async def hide_show_recommendation_tool(
@@ -344,7 +344,7 @@ def register_recommendation_tools(
             "Requires OAuth authentication. "
             "Use Trakt ID, slug, or IMDB ID to identify the movie."
         ),
-        annotations=ToolAnnotations(destructiveHint=True),
+        annotations=ToolAnnotations(destructiveHint=False),
         tags={"write", "auth_required"},
     )
     async def unhide_movie_recommendation_tool(
@@ -360,7 +360,7 @@ def register_recommendation_tools(
             "Requires OAuth authentication. "
             "Use Trakt ID, slug, or IMDB ID to identify the show."
         ),
-        annotations=ToolAnnotations(destructiveHint=True),
+        annotations=ToolAnnotations(destructiveHint=False),
         tags={"write", "auth_required"},
     )
     async def unhide_show_recommendation_tool(

--- a/server/recommendations/tools.py
+++ b/server/recommendations/tools.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Annotated
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from pydantic import BaseModel, Field
 
 from client.pool import get_client

--- a/server/recommendations/tools.py
+++ b/server/recommendations/tools.py
@@ -5,6 +5,7 @@ from collections.abc import Awaitable, Callable
 from typing import Annotated
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 
 from client.pool import get_client
@@ -257,6 +258,8 @@ def register_recommendation_tools(
             "viewing history. Requires OAuth authentication. Use limit parameter "
             "(max 100) to control number of results."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read", "auth_required"},
     )
     async def fetch_movie_recommendations_tool(
         limit: Annotated[
@@ -283,6 +286,8 @@ def register_recommendation_tools(
             "viewing history. Requires OAuth authentication. Use limit parameter "
             "(max 100) to control number of results."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read", "auth_required"},
     )
     async def fetch_show_recommendations_tool(
         limit: Annotated[
@@ -307,6 +312,8 @@ def register_recommendation_tools(
             "Hide a movie from future recommendations. Requires OAuth authentication. "
             "Use Trakt ID, slug, or IMDB ID to identify the movie."
         ),
+        annotations=ToolAnnotations(destructiveHint=True),
+        tags={"write", "auth_required"},
     )
     async def hide_movie_recommendation_tool(
         movie_id: Annotated[str, Field(min_length=1, description=MOVIE_ID_DESCRIPTION)],
@@ -321,6 +328,8 @@ def register_recommendation_tools(
             "Requires OAuth authentication. "
             "Use Trakt ID, slug, or IMDB ID to identify the show."
         ),
+        annotations=ToolAnnotations(destructiveHint=True),
+        tags={"write", "auth_required"},
     )
     async def hide_show_recommendation_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -335,6 +344,8 @@ def register_recommendation_tools(
             "Requires OAuth authentication. "
             "Use Trakt ID, slug, or IMDB ID to identify the movie."
         ),
+        annotations=ToolAnnotations(destructiveHint=True),
+        tags={"write", "auth_required"},
     )
     async def unhide_movie_recommendation_tool(
         movie_id: Annotated[str, Field(min_length=1, description=MOVIE_ID_DESCRIPTION)],
@@ -349,6 +360,8 @@ def register_recommendation_tools(
             "Requires OAuth authentication. "
             "Use Trakt ID, slug, or IMDB ID to identify the show."
         ),
+        annotations=ToolAnnotations(destructiveHint=True),
+        tags={"write", "auth_required"},
     )
     async def unhide_show_recommendation_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],

--- a/server/search/tools.py
+++ b/server/search/tools.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable
 from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from pydantic import Field, ValidationError, field_validator
 
 from client.pool import get_client

--- a/server/search/tools.py
+++ b/server/search/tools.py
@@ -4,6 +4,7 @@ from collections.abc import Awaitable, Callable
 from typing import Annotated, Any
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field, ValidationError, field_validator
 
 from client.pool import get_client
@@ -193,6 +194,8 @@ def register_search_tools(
     @mcp.tool(
         name="search_shows",
         description="Search for TV shows on Trakt by title",
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def search_shows_tool(
         query: Annotated[
@@ -209,6 +212,8 @@ def register_search_tools(
     @mcp.tool(
         name="search_movies",
         description="Search for movies on Trakt by title",
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def search_movies_tool(
         query: Annotated[

--- a/server/seasons/tools.py
+++ b/server/seasons/tools.py
@@ -6,6 +6,7 @@ from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Annotated, Final, Literal, TypeAlias
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from client.pool import get_client
@@ -408,6 +409,8 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch detailed information about a specific TV show season, "
             "including episode count, ratings, and air dates."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_season_info_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -421,6 +424,8 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch all episodes for a specific TV show season "
             "with titles, ratings, and runtime."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_season_episodes_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -433,6 +438,8 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         description=(
             "Fetch ratings and voting statistics for a specific TV show season."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_season_ratings_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -446,6 +453,8 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch engagement statistics for a specific TV show season "
             "including watchers, plays, collectors, and comments."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_season_stats_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -459,6 +468,8 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch cast and crew for a specific TV show season, "
             "including character names and episode counts."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_season_people_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -472,6 +483,8 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch videos (trailers, recaps, etc.) for a specific TV show season. "
             "Set embed_markdown=False for simple links."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_season_videos_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -488,6 +501,8 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         description=(
             "Fetch users currently watching a specific TV show season right now."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_season_watching_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -500,6 +515,8 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
         description=(
             "Fetch translations for a specific TV show season in different languages."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_season_translations_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -511,6 +528,8 @@ def register_season_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
     @mcp.tool(
         name="fetch_season_lists",
         description="Fetch lists that contain a specific TV show season.",
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_season_lists_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],

--- a/server/seasons/tools.py
+++ b/server/seasons/tools.py
@@ -5,7 +5,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Annotated, Final, Literal, TypeAlias
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from pydantic import Field
 
 from client.pool import get_client

--- a/server/shows/resources.py
+++ b/server/shows/resources.py
@@ -7,7 +7,7 @@ from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, TypeAlias
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP
+    from fastmcp import FastMCP
 
     from models.types import ShowResponse
 from pydantic import ValidationError

--- a/server/shows/tools.py
+++ b/server/shows/tools.py
@@ -7,6 +7,7 @@ from collections.abc import Awaitable, Callable
 from typing import Annotated, Literal
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from client.pool import get_client
@@ -573,6 +574,8 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch trending TV shows from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_trending_shows_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -586,6 +589,8 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch popular TV shows from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_popular_shows_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -599,6 +604,8 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch most favorited TV shows from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_favorited_shows_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -616,6 +623,8 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch most played TV shows from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_played_shows_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -633,6 +642,8 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch most watched TV shows from Trakt. "
             "Use page parameter for paginated results, or omit for all results."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_watched_shows_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -650,6 +661,8 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch most anticipated TV shows from Trakt, sorted by list count. "
             "Use page parameter for paginated results, or omit for all results."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_anticipated_shows_tool(
         limit: Annotated[int, Field(description=LIMIT_DESCRIPTION)] = DEFAULT_LIMIT,
@@ -660,6 +673,8 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
     @mcp.tool(
         name="fetch_show_ratings",
         description="Fetch ratings and voting statistics for a specific TV show",
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_show_ratings_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -677,6 +692,8 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "metadata. Basic mode (extended=false): Returns only title, year, and "
             "Trakt ID."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_show_summary_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -693,6 +710,8 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Set embed_markdown=False to return simple links instead of "
             "YouTube iframes."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_show_videos_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -713,6 +732,8 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "based on genres, themes, and viewer patterns. "
             "Use page parameter for paginated results, or omit for all results."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_related_shows_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -727,6 +748,8 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Fetch all seasons for a TV show from Trakt, including episode counts, "
             "aired episodes, and ratings per season."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_show_seasons_tool(
         show_id: Annotated[str, Field(min_length=1, description=SHOW_ID_DESCRIPTION)],
@@ -740,6 +763,8 @@ def register_show_tools(mcp: FastMCP) -> tuple[ToolHandler, ...]:
             "Set include_guest_stars=true to also return guest stars "
             "(warning: returns a lot of data)."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read"},
     )
     async def fetch_show_people_tool(
         show_id: Annotated[

--- a/server/shows/tools.py
+++ b/server/shows/tools.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Annotated, Literal
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from pydantic import Field
 
 from client.pool import get_client

--- a/server/sync/tools.py
+++ b/server/sync/tools.py
@@ -5,7 +5,7 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime
 from typing import Annotated, Any, ClassVar, Literal
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from pydantic import BaseModel, Field, field_validator
 
 from client.pool import get_client

--- a/server/sync/tools.py
+++ b/server/sync/tools.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Annotated, Any, ClassVar, Literal
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field, field_validator
 
 from client.pool import get_client
@@ -945,6 +946,8 @@ def register_sync_tools(
             "Supports optional pagination with 'page' parameter. "
             "Requires OAuth authentication."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read", "auth_required"},
     )
     async def fetch_user_ratings_tool(
         rating_type: Annotated[
@@ -969,6 +972,8 @@ def register_sync_tools(
         description=(
             "Add new ratings for the authenticated user. Requires OAuth authentication."
         ),
+        annotations=ToolAnnotations(destructiveHint=True),
+        tags={"write", "auth_required"},
     )
     async def add_user_ratings_tool(
         rating_type: Annotated[
@@ -990,6 +995,8 @@ def register_sync_tools(
         description=(
             "Remove ratings for the authenticated user. Requires OAuth authentication."
         ),
+        annotations=ToolAnnotations(destructiveHint=True),
+        tags={"write", "auth_required"},
     )
     async def remove_user_ratings_tool(
         rating_type: Annotated[
@@ -1013,6 +1020,8 @@ def register_sync_tools(
             "Supports optional pagination with 'page' parameter and sorting options. "
             "Requires OAuth authentication."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read", "auth_required"},
     )
     async def fetch_user_watchlist_tool(
         watchlist_type: Annotated[
@@ -1047,6 +1056,8 @@ def register_sync_tools(
             "Supports optional notes (VIP only, 500 character limit). "
             "Requires OAuth authentication."
         ),
+        annotations=ToolAnnotations(destructiveHint=True),
+        tags={"write", "auth_required"},
     )
     async def add_user_watchlist_tool(
         watchlist_type: Annotated[
@@ -1069,6 +1080,8 @@ def register_sync_tools(
             "Remove items from the authenticated user's watchlist. "
             "Requires OAuth authentication."
         ),
+        annotations=ToolAnnotations(destructiveHint=True),
+        tags={"write", "auth_required"},
     )
     async def remove_user_watchlist_tool(
         watchlist_type: Annotated[
@@ -1094,6 +1107,8 @@ def register_sync_tools(
             "Supports optional pagination with 'page' parameter. "
             "Requires OAuth authentication."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read", "auth_required"},
     )
     async def fetch_history_tool(
         history_type: Annotated[
@@ -1126,6 +1141,8 @@ def register_sync_tools(
             "as watched. Optionally specify when they were watched. "
             "Requires OAuth authentication."
         ),
+        annotations=ToolAnnotations(destructiveHint=True),
+        tags={"write", "auth_required"},
     )
     async def add_to_history_tool(
         history_type: Annotated[
@@ -1146,6 +1163,8 @@ def register_sync_tools(
             "or episodes from your watched history. "
             "Requires OAuth authentication."
         ),
+        annotations=ToolAnnotations(destructiveHint=True),
+        tags={"write", "auth_required"},
     )
     async def remove_from_history_tool(
         history_type: Annotated[

--- a/server/sync/tools.py
+++ b/server/sync/tools.py
@@ -972,7 +972,7 @@ def register_sync_tools(
         description=(
             "Add new ratings for the authenticated user. Requires OAuth authentication."
         ),
-        annotations=ToolAnnotations(destructiveHint=True),
+        annotations=ToolAnnotations(destructiveHint=False),
         tags={"write", "auth_required"},
     )
     async def add_user_ratings_tool(
@@ -1056,7 +1056,7 @@ def register_sync_tools(
             "Supports optional notes (VIP only, 500 character limit). "
             "Requires OAuth authentication."
         ),
-        annotations=ToolAnnotations(destructiveHint=True),
+        annotations=ToolAnnotations(destructiveHint=False),
         tags={"write", "auth_required"},
     )
     async def add_user_watchlist_tool(
@@ -1141,7 +1141,7 @@ def register_sync_tools(
             "as watched. Optionally specify when they were watched. "
             "Requires OAuth authentication."
         ),
-        annotations=ToolAnnotations(destructiveHint=True),
+        annotations=ToolAnnotations(destructiveHint=False),
         tags={"write", "auth_required"},
     )
     async def add_to_history_tool(

--- a/server/user/resources.py
+++ b/server/user/resources.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable
 from typing import TypeAlias
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 
 from client.pool import get_client
 from client.user import UserClient

--- a/server/user/tools.py
+++ b/server/user/tools.py
@@ -4,6 +4,7 @@ from collections.abc import Awaitable, Callable
 from typing import Annotated, Any
 
 from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field, ValidationError
 
 from client.pool import get_client
@@ -168,6 +169,8 @@ def register_user_tools(mcp: FastMCP) -> tuple[ToolHandler, ToolHandler]:
             "use fetch_history with history_type='shows' and item_id instead. "
             "Requires OAuth authentication."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read", "auth_required"},
     )
     @ToolErrors.with_error_handling(
         operation="fetch_user_watched_shows_tool",
@@ -194,6 +197,8 @@ def register_user_tools(mcp: FastMCP) -> tuple[ToolHandler, ToolHandler]:
             "use fetch_history with history_type='movies' and item_id instead. "
             "Requires OAuth authentication."
         ),
+        annotations=ToolAnnotations(readOnlyHint=True),
+        tags={"read", "auth_required"},
     )
     @ToolErrors.with_error_handling(
         operation="fetch_user_watched_movies_tool",

--- a/server/user/tools.py
+++ b/server/user/tools.py
@@ -3,7 +3,7 @@
 from collections.abc import Awaitable, Callable
 from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from pydantic import BaseModel, Field, ValidationError
 
 from client.pool import get_client

--- a/tests/client/auth/test_auth_flow.py
+++ b/tests/client/auth/test_auth_flow.py
@@ -201,7 +201,8 @@ async def test_device_token_400_returns_authorization_pending() -> None:
 
         client = AuthClient()
 
-        with pytest.raises(AuthorizationPendingError):
+        with pytest.raises(AuthorizationPendingError) as exc_info:
             await client.get_device_token("device_code_123")
 
+        assert exc_info.value.data["error_type"] == "auth_pending"
         assert client.is_authenticated() is False

--- a/tests/client/auth/test_auth_flow.py
+++ b/tests/client/auth/test_auth_flow.py
@@ -8,7 +8,6 @@ import pytest
 from client.auth import AuthClient
 from models.auth import TraktAuthToken, TraktDeviceCode
 from utils.api.error_types import AuthorizationPendingError
-from utils.api.errors import InvalidParamsError
 
 
 @pytest.mark.asyncio
@@ -172,26 +171,28 @@ async def test_device_token_pending_authorization():
 
 
 @pytest.mark.asyncio
-async def test_device_token_expired():
-    """Test getting a device token when the code has expired."""
-    # Mock a 400 error response for expired code
+async def test_device_token_400_returns_authorization_pending():
+    """A 400 on /oauth/device/token surfaces as AuthorizationPendingError.
+
+    Trakt returns HTTP 400 with no discriminating body while the user has
+    not yet authorized in the browser. The endpoint identity is the
+    canonical signal — body content is not required.
+    """
     mock_error_response = MagicMock()
     mock_error_response.raise_for_status.side_effect = httpx.HTTPStatusError(
         "Bad Request",
         request=MagicMock(),
-        response=MagicMock(status_code=400, text="expired_token"),
+        response=MagicMock(status_code=400, text=""),
     )
 
-    # Patch the AsyncClient to return our mock error response
     with (
         patch("httpx.AsyncClient") as mock_client,
-        patch("os.path.exists", return_value=False),  # No existing auth token
+        patch("os.path.exists", return_value=False),
         patch.dict(
             os.environ,
             {"TRAKT_CLIENT_ID": "test_id", "TRAKT_CLIENT_SECRET": "test_secret"},
         ),
     ):
-        # Create mock instance with async methods
         mock_instance = MagicMock()
         mock_instance.post = AsyncMock(return_value=mock_error_response)
         mock_instance.get = AsyncMock()
@@ -200,12 +201,7 @@ async def test_device_token_expired():
 
         client = AuthClient()
 
-        # Try to get a token, should raise InvalidParamsError because code has expired
-        with pytest.raises(InvalidParamsError) as exc_info:
+        with pytest.raises(AuthorizationPendingError):
             await client.get_device_token("device_code_123")
 
-        # Verify the error contains information about expired token
-        assert "expired_token" in str(exc_info.value.data)
-
-        # Verify the client is not authenticated
         assert client.is_authenticated() is False

--- a/tests/client/auth/test_auth_flow.py
+++ b/tests/client/auth/test_auth_flow.py
@@ -204,5 +204,8 @@ async def test_device_token_400_returns_authorization_pending() -> None:
         with pytest.raises(AuthorizationPendingError) as exc_info:
             await client.get_device_token("device_code_123")
 
-        assert exc_info.value.data["error_type"] == "auth_pending"
+        assert (
+            exc_info.value.data
+            and exc_info.value.data.get("error_type") == "auth_pending"
+        )
         assert client.is_authenticated() is False

--- a/tests/client/auth/test_auth_flow.py
+++ b/tests/client/auth/test_auth_flow.py
@@ -171,7 +171,7 @@ async def test_device_token_pending_authorization():
 
 
 @pytest.mark.asyncio
-async def test_device_token_400_returns_authorization_pending():
+async def test_device_token_400_returns_authorization_pending() -> None:
     """A 400 on /oauth/device/token surfaces as AuthorizationPendingError.
 
     Trakt returns HTTP 400 with no discriminating body while the user has

--- a/tests/test_mcp_compliance.py
+++ b/tests/test_mcp_compliance.py
@@ -7,12 +7,12 @@ the FastMCP CLI (``fastmcp inspect --format mcp``) — no Node dependency.
 import json
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 import pytest
 
-REPO_ROOT = Path(__file__).parent.parent
-SERVER_PATH = str(REPO_ROOT / "server.py")
+REPO_ROOT: Final[Path] = Path(__file__).parent.parent
+SERVER_PATH: Final[str] = str(REPO_ROOT / "server.py")
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_mcp_compliance.py
+++ b/tests/test_mcp_compliance.py
@@ -331,7 +331,7 @@ class TestMCPFunctionalCompliance:
         """Test that server uses compatible MCP transport."""
         # Verify FastMCP is being used (handles JSON-RPC 2.0 transport)
         try:
-            from mcp.server.fastmcp import FastMCP
+            from fastmcp import FastMCP
 
             import server
 

--- a/tests/test_mcp_compliance.py
+++ b/tests/test_mcp_compliance.py
@@ -1,7 +1,7 @@
 """MCP Compliance Test Suite.
 
-This module tests complete MCP specification compliance for the Trakt MCP server.
-Tests validate all core MCP features: tools, resources, prompts, and capabilities.
+Tests complete MCP specification compliance for the Trakt MCP server using
+the FastMCP CLI (``fastmcp inspect --format mcp``) — no Node dependency.
 """
 
 import json
@@ -11,223 +11,128 @@ from typing import Any
 
 import pytest
 
+REPO_ROOT = Path(__file__).parent.parent
+SERVER_PATH = str(REPO_ROOT / "server.py")
+
+
+@pytest.fixture(scope="module")
+def mcp_report(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Any]:
+    """Run ``fastmcp inspect --format mcp`` once, return parsed report.
+
+    Writing to a file (``-o``) avoids interleaving with the server's startup
+    logs that go to stdout.
+    """
+    report_path = tmp_path_factory.mktemp("mcp") / "report.json"
+    result = subprocess.run(
+        [
+            "fastmcp",
+            "inspect",
+            SERVER_PATH,
+            "--format",
+            "mcp",
+            "-o",
+            str(report_path),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"fastmcp inspect failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+    return json.loads(report_path.read_text())
+
 
 class TestMCPCompliance:
     """Test MCP specification compliance."""
 
-    @pytest.fixture
-    def mcp_inspector_base_cmd(self) -> list[str]:
-        """Base command for MCP inspector."""
-        return [
-            "npx",
-            "@modelcontextprotocol/inspector",
-            "--cli",
-            "python",
-            "server.py",
-        ]
-
-    def _run_mcp_command(self, cmd: list[str]) -> dict[str, Any]:
-        """Run MCP inspector command and return parsed JSON result."""
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            cwd=Path(__file__).parent.parent,
-            timeout=60,
-        )
-
-        if result.returncode != 0:
-            pytest.fail(
-                f"MCP command failed: {' '.join(cmd)}\n"
-                + f"stdout: {result.stdout}\n"
-                + f"stderr: {result.stderr}"
-            )
-
-        try:
-            return json.loads(result.stdout)
-        except json.JSONDecodeError as e:
-            pytest.fail(
-                f"Failed to parse JSON response from: {' '.join(cmd)}\n"
-                + f"Output: {result.stdout}\n"
-                + f"Error: {e}"
-            )
-
-    def test_tools_list_compliance(self, mcp_inspector_base_cmd: list[str]) -> None:
-        """Test that all tools are listed with complete metadata."""
-        cmd = [*mcp_inspector_base_cmd, "--method", "tools/list"]
-        data = self._run_mcp_command(cmd)
-
-        # Verify response structure
-        assert "tools" in data, "Response missing 'tools' key"
-        tools: list[dict[str, Any]] = data["tools"]
+    def test_tools_list_compliance(self, mcp_report: dict[str, Any]) -> None:
+        """All tools are listed with complete metadata."""
+        tools: list[dict[str, Any]] = mcp_report["tools"]
         assert isinstance(tools, list), "Tools should be a list"
         assert len(tools) >= 26, f"Expected at least 26 tools, got {len(tools)}"
 
-        # Check each tool has required MCP fields
         for tool in tools:
             assert "name" in tool, f"Tool missing 'name': {tool}"
             assert "description" in tool, f"Tool missing 'description': {tool}"
             assert "inputSchema" in tool, f"Tool missing 'inputSchema': {tool}"
 
-            # Validate tool name is non-empty string
-            assert isinstance(tool["name"], str), (
-                f"Tool name must be string: {tool['name']}"
+            assert isinstance(tool["name"], str) and tool["name"].strip(), (
+                f"Tool name must be non-empty string: {tool['name']}"
             )
-            assert tool["name"].strip(), f"Tool name cannot be empty: {tool['name']}"
+            assert (
+                isinstance(tool["description"], str) and tool["description"].strip()
+            ), f"Tool description must be non-empty string: {tool['description']}"
 
-            # Validate description is non-empty string
-            assert isinstance(tool["description"], str), (
-                f"Tool description must be string: {tool['description']}"
-            )
-            assert tool["description"].strip(), (
-                f"Tool description cannot be empty: {tool['description']}"
-            )
-
-            # Validate input schema structure
             schema: dict[str, Any] = tool["inputSchema"]
             assert isinstance(schema, dict), f"Input schema must be dict: {schema}"
-            assert "type" in schema, f"Input schema missing 'type': {schema}"
-            assert schema["type"] == "object", (
+            assert schema.get("type") == "object", (
                 f"Input schema type must be 'object': {schema}"
             )
 
-    def test_resources_list_compliance(self, mcp_inspector_base_cmd: list[str]) -> None:
-        """Test that all resources are listed with complete metadata."""
-        cmd = [*mcp_inspector_base_cmd, "--method", "resources/list"]
-        data = self._run_mcp_command(cmd)
-
-        # Verify response structure
-        assert "resources" in data, "Response missing 'resources' key"
-        resources: list[dict[str, Any]] = data["resources"]
+    def test_resources_list_compliance(self, mcp_report: dict[str, Any]) -> None:
+        """All resources are listed with complete metadata."""
+        resources: list[dict[str, Any]] = mcp_report["resources"]
         assert isinstance(resources, list), "Resources should be a list"
         assert len(resources) >= 13, (
             f"Expected at least 13 resources, got {len(resources)}"
         )
 
-        # Check each resource has required MCP fields
         for resource in resources:
-            assert "uri" in resource, f"Resource missing 'uri': {resource}"
-            assert "name" in resource, f"Resource missing 'name': {resource}"
-            assert "description" in resource, (
-                f"Resource missing 'description': {resource}"
-            )
-            assert "mimeType" in resource, f"Resource missing 'mimeType': {resource}"
-
-            # Validate resource fields
-            assert isinstance(resource["uri"], str), (
-                f"Resource uri must be string: {resource['uri']}"
-            )
-            assert resource["uri"].strip(), (
-                f"Resource uri cannot be empty: {resource['uri']}"
-            )
-
-            assert isinstance(resource["name"], str), (
-                f"Resource name must be string: {resource['name']}"
-            )
-            assert resource["name"].strip(), (
-                f"Resource name cannot be empty: {resource['name']}"
-            )
-
-            assert isinstance(resource["description"], str), (
-                f"Resource description must be string: {resource['description']}"
-            )
-            assert resource["description"].strip(), (
-                f"Resource description cannot be empty: {resource['description']}"
-            )
-
-            assert isinstance(resource["mimeType"], str), (
-                f"Resource mimeType must be string: {resource['mimeType']}"
-            )
+            for field in ("uri", "name", "description", "mimeType"):
+                assert field in resource, f"Resource missing '{field}': {resource}"
+                value = resource[field]
+                assert isinstance(value, str) and value.strip(), (
+                    f"Resource {field} must be non-empty string: {value}"
+                )
             assert resource["mimeType"] == "text/markdown", (
                 f"Expected 'text/markdown', got: {resource['mimeType']}"
             )
 
-    def test_prompts_list_compliance(self, mcp_inspector_base_cmd: list[str]) -> None:
-        """Test that prompts are available with complete metadata."""
-        cmd = [*mcp_inspector_base_cmd, "--method", "prompts/list"]
-        data = self._run_mcp_command(cmd)
-
-        # Verify response structure
-        assert "prompts" in data, "Response missing 'prompts' key"
-        prompts: list[dict[str, Any]] = data["prompts"]
+    def test_prompts_list_compliance(self, mcp_report: dict[str, Any]) -> None:
+        """Prompts are available with complete metadata."""
+        prompts: list[dict[str, Any]] = mcp_report["prompts"]
         assert isinstance(prompts, list), "Prompts should be a list"
         assert len(prompts) >= 2, f"Expected at least 2 prompts, got {len(prompts)}"
 
-        # Check each prompt has required MCP fields
         expected_prompts = {"discover_trending", "search_entertainment"}
         found_prompts: set[str] = set()
 
         for prompt in prompts:
-            assert "name" in prompt, f"Prompt missing 'name': {prompt}"
-            assert "description" in prompt, f"Prompt missing 'description': {prompt}"
-            assert "arguments" in prompt, f"Prompt missing 'arguments': {prompt}"
+            for field in ("name", "description", "arguments"):
+                assert field in prompt, f"Prompt missing '{field}': {prompt}"
 
-            # Validate prompt fields
-            assert isinstance(prompt["name"], str), (
-                f"Prompt name must be string: {prompt['name']}"
+            assert isinstance(prompt["name"], str) and prompt["name"].strip(), (
+                f"Prompt name must be non-empty string: {prompt['name']}"
             )
-            assert prompt["name"].strip(), (
-                f"Prompt name cannot be empty: {prompt['name']}"
-            )
-
-            assert isinstance(prompt["description"], str), (
-                f"Prompt description must be string: {prompt['description']}"
-            )
-            assert prompt["description"].strip(), (
-                f"Prompt description cannot be empty: {prompt['description']}"
-            )
-
+            assert (
+                isinstance(prompt["description"], str) and prompt["description"].strip()
+            ), f"Prompt description must be non-empty string: {prompt['description']}"
             assert isinstance(prompt["arguments"], list), (
                 f"Prompt arguments must be list: {prompt['arguments']}"
             )
-
             found_prompts.add(prompt["name"])
 
-        # Verify we have the expected prompts
-        missing_prompts = expected_prompts - found_prompts
-        assert not missing_prompts, f"Missing expected prompts: {missing_prompts}"
+        missing = expected_prompts - found_prompts
+        assert not missing, f"Missing expected prompts: {missing}"
 
-    def test_server_info_compliance(self, mcp_inspector_base_cmd: list[str]) -> None:
-        """Test server provides proper info response."""
-        # Note: MCP inspector doesn't have a direct server info command,
-        # but we can verify the server starts and responds properly
-        cmd = [*mcp_inspector_base_cmd, "--method", "tools/list"]
-        data = self._run_mcp_command(cmd)
+    def test_server_info_compliance(self, mcp_report: dict[str, Any]) -> None:
+        """Server reports identifying info."""
+        info: dict[str, Any] = mcp_report["serverInfo"]
+        assert info["name"] == "trakt-mcp-server", (
+            f"Unexpected server name: {info['name']}"
+        )
+        assert isinstance(info["version"], str) and info["version"].strip(), (
+            f"Server version must be non-empty string: {info['version']}"
+        )
 
-        # If tools/list works, the server is properly initialized
-        assert "tools" in data, "Server failed to provide tools list"
-
-    def test_capability_negotiation(self, mcp_inspector_base_cmd: list[str]) -> None:
-        """Test server capabilities are properly declared."""
-        # Test that all three core capabilities are available
-
-        # Test tools capability
-        tools_cmd = [*mcp_inspector_base_cmd, "--method", "tools/list"]
-        tools_data = self._run_mcp_command(tools_cmd)
-        assert "tools" in tools_data, "Tools capability not available"
-        assert len(tools_data["tools"]) > 0, "No tools available"
-
-        # Test resources capability
-        resources_cmd = [*mcp_inspector_base_cmd, "--method", "resources/list"]
-        resources_data = self._run_mcp_command(resources_cmd)
-        assert "resources" in resources_data, "Resources capability not available"
-        assert len(resources_data["resources"]) > 0, "No resources available"
-
-        # Test prompts capability
-        prompts_cmd = [*mcp_inspector_base_cmd, "--method", "prompts/list"]
-        prompts_data = self._run_mcp_command(prompts_cmd)
-        assert "prompts" in prompts_data, "Prompts capability not available"
-        assert len(prompts_data["prompts"]) > 0, "No prompts available"
-
-    def test_mcp_protocol_version(self, mcp_inspector_base_cmd: list[str]) -> None:
-        """Test that server supports target MCP protocol version."""
-        # The fact that MCP inspector can communicate with our server
-        # indicates protocol compatibility. FastMCP handles version negotiation.
-        cmd = [*mcp_inspector_base_cmd, "--method", "tools/list"]
-        data = self._run_mcp_command(cmd)
-
-        # Successful communication indicates protocol compatibility
-        assert "tools" in data, "Protocol version incompatibility detected"
+    def test_capability_negotiation(self, mcp_report: dict[str, Any]) -> None:
+        """All three core capabilities declare non-empty lists."""
+        assert mcp_report["tools"], "No tools available"
+        assert mcp_report["resources"], "No resources available"
+        assert mcp_report["prompts"], "No prompts available"
 
     @pytest.mark.parametrize(
         "tool_name",
@@ -242,21 +147,14 @@ class TestMCPCompliance:
         ],
     )
     def test_critical_tools_available(
-        self, mcp_inspector_base_cmd: list[str], tool_name: str
+        self, mcp_report: dict[str, Any], tool_name: str
     ) -> None:
-        """Test that critical tools are available and properly configured."""
-        cmd = [*mcp_inspector_base_cmd, "--method", "tools/list"]
-        data = self._run_mcp_command(cmd)
-
-        tools = data["tools"]
-        tool_names = [tool["name"] for tool in tools]
-
-        assert tool_name in tool_names, (
-            f"Critical tool '{tool_name}' not found in: {tool_names}"
+        """Critical tools are available and properly configured."""
+        tools = mcp_report["tools"]
+        tool = next((t for t in tools if t["name"] == tool_name), None)
+        assert tool is not None, (
+            f"Critical tool '{tool_name}' not found in: {[t['name'] for t in tools]}"
         )
-
-        # Find the specific tool and validate its structure
-        tool = next(t for t in tools if t["name"] == tool_name)
         assert tool["description"], f"Tool '{tool_name}' missing description"
         assert "inputSchema" in tool, f"Tool '{tool_name}' missing input schema"
 
@@ -270,228 +168,163 @@ class TestMCPCompliance:
         ],
     )
     def test_critical_resources_available(
-        self, mcp_inspector_base_cmd: list[str], resource_uri: str
+        self, mcp_report: dict[str, Any], resource_uri: str
     ) -> None:
-        """Test that critical resources are available and properly configured."""
-        cmd = [*mcp_inspector_base_cmd, "--method", "resources/list"]
-        data = self._run_mcp_command(cmd)
-
-        resources = data["resources"]
-        resource_uris = [resource["uri"] for resource in resources]
-
-        assert resource_uri in resource_uris, (
-            f"Critical resource '{resource_uri}' not found in: {resource_uris}"
+        """Critical resources are available and properly configured."""
+        resources = mcp_report["resources"]
+        resource = next((r for r in resources if r["uri"] == resource_uri), None)
+        assert resource is not None, (
+            f"Critical resource '{resource_uri}' not found in: "
+            f"{[r['uri'] for r in resources]}"
         )
-
-        # Find the specific resource and validate its structure
-        resource = next(r for r in resources if r["uri"] == resource_uri)
         assert resource["description"], f"Resource '{resource_uri}' missing description"
         assert resource["mimeType"] == "text/markdown", (
             f"Resource '{resource_uri}' wrong mime type"
         )
 
-    def test_error_handling_compliance(self, mcp_inspector_base_cmd: list[str]) -> None:
-        """Test that error handling follows MCP specification."""
-        # Test with an invalid method to verify error response structure
-        cmd = [*mcp_inspector_base_cmd, "--method", "invalid/method"]
-
+    def test_error_handling_compliance(self) -> None:
+        """Invoking a non-existent tool returns a structured error."""
         result = subprocess.run(
-            cmd,
+            [
+                "fastmcp",
+                "call",
+                SERVER_PATH,
+                "definitely_not_a_real_tool",
+            ],
             capture_output=True,
             text=True,
-            cwd=Path(__file__).parent.parent,
+            cwd=REPO_ROOT,
             timeout=60,
         )
+        assert result.returncode != 0, "Invalid tool should return error"
 
-        # Should fail with proper error response
-        assert result.returncode != 0, "Invalid method should return error"
 
-        # Error should be properly formatted (MCP inspector handles JSON-RPC format)
-        # Getting a structured error response indicates compliance
+class TestToolAnnotationsAndTags:
+    """Verify tool annotations and tags introduced by the FastMCP 3 gap closure."""
+
+    def test_every_tool_has_tags(self, mcp_report: dict[str, Any]) -> None:
+        """Every tool carries at least one tag (FastMCP _meta)."""
+        untagged = [
+            t["name"]
+            for t in mcp_report["tools"]
+            if not t.get("_meta", {}).get("fastmcp", {}).get("tags")
+        ]
+        assert not untagged, f"Tools missing tags: {untagged}"
+
+    def test_annotations_populated_except_start_device_auth(
+        self, mcp_report: dict[str, Any]
+    ) -> None:
+        """Only ``start_device_auth`` lacks annotations (deliberate, flow-starter)."""
+        unannotated = [
+            t["name"] for t in mcp_report["tools"] if t.get("annotations") is None
+        ]
+        assert unannotated == ["start_device_auth"], (
+            f"Unexpected tools with null annotations: {unannotated}"
+        )
+
+    def test_all_write_tools_marked_destructive(
+        self, mcp_report: dict[str, Any]
+    ) -> None:
+        """Every tool tagged ``write`` declares ``destructiveHint=True``."""
+        for tool in mcp_report["tools"]:
+            tags = tool.get("_meta", {}).get("fastmcp", {}).get("tags", [])
+            if "write" in tags:
+                ann: dict[str, Any] = tool.get("annotations") or {}
+                assert ann.get("destructiveHint") is True, (
+                    f"Write tool {tool['name']} missing destructiveHint=True"
+                )
+
+    def test_all_read_tools_marked_readonly(self, mcp_report: dict[str, Any]) -> None:
+        """Every tool tagged ``read`` declares ``readOnlyHint=True``."""
+        for tool in mcp_report["tools"]:
+            tags = tool.get("_meta", {}).get("fastmcp", {}).get("tags", [])
+            if "read" in tags:
+                ann: dict[str, Any] = tool.get("annotations") or {}
+                assert ann.get("readOnlyHint") is True, (
+                    f"Read tool {tool['name']} missing readOnlyHint=True"
+                )
+
+    def test_auth_required_covers_writes_and_user_reads(
+        self, mcp_report: dict[str, Any]
+    ) -> None:
+        """``auth_required`` tag covers every write (except ``clear_auth``) and
+        every user-scoped read."""
+        auth_required = {
+            t["name"]
+            for t in mcp_report["tools"]
+            if "auth_required" in t.get("_meta", {}).get("fastmcp", {}).get("tags", [])
+        }
+        # All non-auth-flow writes
+        expected_writes = {
+            "add_to_history",
+            "remove_from_history",
+            "add_user_ratings",
+            "remove_user_ratings",
+            "add_user_watchlist",
+            "remove_user_watchlist",
+            "checkin_to_show",
+            "hide_movie_recommendation",
+            "hide_show_recommendation",
+            "unhide_movie_recommendation",
+            "unhide_show_recommendation",
+            "remove_playback_item",
+        }
+        # User-scoped reads
+        expected_reads = {
+            "fetch_user_ratings",
+            "fetch_user_watchlist",
+            "fetch_history",
+            "fetch_user_watched_shows",
+            "fetch_user_watched_movies",
+            "fetch_show_progress",
+            "fetch_playback_progress",
+            "fetch_movie_recommendations",
+            "fetch_show_recommendations",
+        }
+        missing = (expected_writes | expected_reads) - auth_required
+        assert not missing, f"Tools missing auth_required tag: {missing}"
 
 
 class TestMCPFunctionalCompliance:
-    """Test functional MCP compliance beyond basic structure."""
+    """In-process functional compliance checks."""
 
-    def test_server_startup_and_shutdown(self) -> None:
-        """Test that server starts and shuts down properly."""
-        # Test that the server can be imported and started
-        try:
-            # Import should work without errors
-            import server
+    def test_server_startup(self) -> None:
+        """Server module imports and ``create_server()`` returns a FastMCP instance."""
+        from fastmcp import FastMCP
 
-            # Creating server should work
-            mcp_server = server.create_server()
-            assert mcp_server is not None, "Failed to create MCP server"
-
-        except Exception as e:
-            pytest.fail(f"Server startup failed: {e}")
-
-    def test_mcp_transport_compatibility(self) -> None:
-        """Test that server uses compatible MCP transport."""
-        # Verify FastMCP is being used (handles JSON-RPC 2.0 transport)
-        try:
-            from fastmcp import FastMCP
-
-            import server
-
-            mcp_server = server.create_server()
-            assert isinstance(mcp_server, FastMCP), (
-                "Server must use FastMCP for MCP compliance"
-            )
-
-        except ImportError:
-            pytest.fail("FastMCP not available - required for MCP compliance")
-        except Exception as e:
-            pytest.fail(f"MCP transport test failed: {e}")
-
-    def test_async_support(self) -> None:
-        """Test that server properly supports async operations."""
-        # All our tools and resources are async - verify the server supports this
         import server
 
-        try:
-            mcp_server = server.create_server()
-
-            # Server should be configured for async operation
-            # FastMCP handles this automatically
-            assert mcp_server is not None, "Server creation failed"
-
-        except Exception as e:
-            pytest.fail(f"Async support test failed: {e}")
+        mcp_server = server.create_server()
+        assert isinstance(mcp_server, FastMCP), (
+            "Server must use FastMCP for MCP compliance"
+        )
 
 
 class TestMCPSpecificationDetails:
-    """Test specific MCP specification requirements."""
+    """Stricter per-item metadata checks (reads the same shared report)."""
 
-    def test_json_rpc_compliance(self) -> None:
-        """Test JSON-RPC 2.0 compliance through FastMCP."""
-        # FastMCP provides JSON-RPC 2.0 compliance
-        # We verify this by checking successful communication with MCP inspector
-        cmd = [
-            "npx",
-            "@modelcontextprotocol/inspector",
-            "--cli",
-            "python",
-            "server.py",
-            "--method",
-            "tools/list",
-        ]
-
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            cwd=Path(__file__).parent.parent,
-            timeout=60,
-        )
-
-        assert result.returncode == 0, f"JSON-RPC communication failed: {result.stderr}"
-
-        # Should return valid JSON
-        try:
-            data = json.loads(result.stdout)
-            assert "tools" in data, "Invalid JSON-RPC response structure"
-        except json.JSONDecodeError:
-            pytest.fail(f"Invalid JSON response: {result.stdout}")
-
-    def test_mcp_message_format(self) -> None:
-        """Test that messages follow MCP format specification."""
-        # MCP inspector validates message format - successful communication indicates
-        # compliance
-        cmd = [
-            "npx",
-            "@modelcontextprotocol/inspector",
-            "--cli",
-            "python",
-            "server.py",
-            "--method",
-            "prompts/list",
-        ]
-
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            cwd=Path(__file__).parent.parent,
-            timeout=60,
-        )
-
-        assert result.returncode == 0, "MCP message format validation failed"
-
-        data = json.loads(result.stdout)
-        assert "prompts" in data, "MCP message format incorrect"
-
-    def test_metadata_completeness(self) -> None:
-        """Test that all metadata fields are complete and valid."""
-        # Run all list commands and verify metadata completeness
-        base_cmd = [
-            "npx",
-            "@modelcontextprotocol/inspector",
-            "--cli",
-            "python",
-            "server.py",
-        ]
-
-        # Test tools metadata
-        tools_result = subprocess.run(
-            [*base_cmd, "--method", "tools/list"],
-            capture_output=True,
-            text=True,
-            cwd=Path(__file__).parent.parent,
-            timeout=60,
-        )
-        assert tools_result.returncode == 0
-        tools_data = json.loads(tools_result.stdout)
-
-        for tool in tools_data["tools"]:
-            # Every tool must have non-empty description
+    def test_metadata_completeness(self, mcp_report: dict[str, Any]) -> None:
+        """Every tool/resource/prompt has complete, valid metadata."""
+        for tool in mcp_report["tools"]:
             assert tool["description"].strip(), (
                 f"Tool {tool['name']} has empty description"
             )
-            # Every tool must have valid input schema
             assert tool["inputSchema"]["type"] == "object", (
                 f"Tool {tool['name']} has invalid schema"
             )
 
-        # Test resources metadata
-        resources_result = subprocess.run(
-            [*base_cmd, "--method", "resources/list"],
-            capture_output=True,
-            text=True,
-            cwd=Path(__file__).parent.parent,
-            timeout=60,
-        )
-        assert resources_result.returncode == 0
-        resources_data = json.loads(resources_result.stdout)
-
-        for resource in resources_data["resources"]:
-            # Every resource must have non-empty description
+        for resource in mcp_report["resources"]:
             assert resource["description"].strip(), (
                 f"Resource {resource['name']} has empty description"
             )
-            # Every resource must have valid mime type
             assert resource["mimeType"] == "text/markdown", (
                 f"Resource {resource['name']} has invalid mime type"
             )
 
-        # Test prompts metadata
-        prompts_result = subprocess.run(
-            [*base_cmd, "--method", "prompts/list"],
-            capture_output=True,
-            text=True,
-            cwd=Path(__file__).parent.parent,
-            timeout=60,
-        )
-        assert prompts_result.returncode == 0
-        prompts_data = json.loads(prompts_result.stdout)
-
-        for prompt in prompts_data["prompts"]:
-            # Every prompt must have non-empty description
+        for prompt in mcp_report["prompts"]:
             assert prompt["description"].strip(), (
                 f"Prompt {prompt['name']} has empty description"
             )
-            # Every prompt must have arguments list (can be empty)
             assert isinstance(prompt["arguments"], list), (
                 f"Prompt {prompt['name']} has invalid arguments"
             )

--- a/tests/test_mcp_compliance.py
+++ b/tests/test_mcp_compliance.py
@@ -197,6 +197,10 @@ class TestMCPCompliance:
             timeout=60,
         )
         assert result.returncode != 0, "Invalid tool should return error"
+        combined = result.stdout + result.stderr
+        assert "definitely_not_a_real_tool" in combined, (
+            f"Error output should name the unknown tool:\n{combined}"
+        )
 
 
 class TestToolAnnotationsAndTags:
@@ -211,15 +215,20 @@ class TestToolAnnotationsAndTags:
         ]
         assert not untagged, f"Tools missing tags: {untagged}"
 
-    def test_annotations_populated_except_start_device_auth(
+    def test_annotations_populated_except_auth_flow_tools(
         self, mcp_report: dict[str, Any]
     ) -> None:
-        """Only ``start_device_auth`` lacks annotations (deliberate, flow-starter)."""
-        unannotated = [
+        """Only the device-flow tools lack annotations (deliberate).
+
+        ``start_device_auth`` starts the flow; ``check_auth_status`` polls it
+        and persists the token on success, so neither is read-only nor a
+        conventional write.
+        """
+        unannotated = {
             t["name"] for t in mcp_report["tools"] if t.get("annotations") is None
-        ]
-        assert unannotated == ["start_device_auth"], (
-            f"Unexpected tools with null annotations: {unannotated}"
+        }
+        assert unannotated == {"start_device_auth", "check_auth_status"}, (
+            f"Unexpected tools with null annotations: {sorted(unannotated)}"
         )
 
     def test_write_tools_destructive_partition(

--- a/tests/test_mcp_compliance.py
+++ b/tests/test_mcp_compliance.py
@@ -222,16 +222,48 @@ class TestToolAnnotationsAndTags:
             f"Unexpected tools with null annotations: {unannotated}"
         )
 
-    def test_all_write_tools_marked_destructive(
+    def test_write_tools_destructive_partition(
         self, mcp_report: dict[str, Any]
     ) -> None:
-        """Every tool tagged ``write`` declares ``destructiveHint=True``."""
+        """Writes split into destructive (lose state) vs additive (create/toggle)."""
+        destructive_writes = {
+            "clear_auth",
+            "remove_user_ratings",
+            "remove_user_watchlist",
+            "remove_from_history",
+            "remove_playback_item",
+        }
+        additive_writes = {
+            "checkin_to_show",
+            "add_user_ratings",
+            "add_user_watchlist",
+            "add_to_history",
+            "hide_movie_recommendation",
+            "hide_show_recommendation",
+            "unhide_movie_recommendation",
+            "unhide_show_recommendation",
+        }
+
+        write_tools = {
+            t["name"]
+            for t in mcp_report["tools"]
+            if "write" in t.get("_meta", {}).get("fastmcp", {}).get("tags", [])
+        }
+        expected = destructive_writes | additive_writes
+        assert write_tools == expected, (
+            f"Write tag drift — unexpected: {write_tools - expected}, "
+            f"missing: {expected - write_tools}"
+        )
+
         for tool in mcp_report["tools"]:
-            tags = tool.get("_meta", {}).get("fastmcp", {}).get("tags", [])
-            if "write" in tags:
-                ann: dict[str, Any] = tool.get("annotations") or {}
+            ann: dict[str, Any] = tool.get("annotations") or {}
+            if tool["name"] in destructive_writes:
                 assert ann.get("destructiveHint") is True, (
-                    f"Write tool {tool['name']} missing destructiveHint=True"
+                    f"{tool['name']} must have destructiveHint=True"
+                )
+            elif tool["name"] in additive_writes:
+                assert ann.get("destructiveHint") is False, (
+                    f"{tool['name']} must have destructiveHint=False"
                 )
 
     def test_all_read_tools_marked_readonly(self, mcp_report: dict[str, Any]) -> None:

--- a/tests/utils/api/test_error_handler.py
+++ b/tests/utils/api/test_error_handler.py
@@ -128,6 +128,23 @@ class TestStatusCodeHandlers:
         assert result.data is not None
         assert result.data["device_code"] == "device123"
 
+    def test_handle_bad_request_device_token_empty_body(self) -> None:
+        """400 on /oauth/device/token with empty body is authorization_pending.
+
+        Trakt sends HTTP 400 with no discriminating body while the user has
+        not yet authorized in the browser. Endpoint identity is the canonical
+        signal — not the response body.
+        """
+        result = TraktAPIErrorHandler.handle_bad_request(
+            endpoint="/oauth/device/token",
+            response_text="",
+            resource_id="device123",
+        )
+
+        assert isinstance(result, AuthorizationPendingError)
+        assert result.data is not None
+        assert result.data["device_code"] == "device123"
+
     def test_handle_bad_request_validation_error(self) -> None:
         """Test 400 Bad Request with validation keywords."""
         result = TraktAPIErrorHandler.handle_bad_request(

--- a/utils/api/error_handler.py
+++ b/utils/api/error_handler.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import httpx
 
+from config.endpoints.auth import AUTH_ENDPOINTS
 from utils.api.errors import (
     InternalError,
     InvalidParamsError,
@@ -116,9 +117,15 @@ class TraktAPIErrorHandler:
     ) -> InvalidParamsError | AuthorizationPendingError | TraktValidationError:
         """Handle 400 Bad Request errors."""
         response_text = context.get("response_text", "")
+        endpoint = context.get("endpoint") or ""
 
-        # Check for authorization pending (OAuth device flow)
-        if "authorization_pending" in response_text.lower():
+        # Trakt's OAuth device-flow token endpoint returns HTTP 400 with an
+        # empty body while the user has not yet authorized. Endpoint identity
+        # is the canonical signal; the substring check is a defensive fallback.
+        if (
+            endpoint.endswith(AUTH_ENDPOINTS["device_token"])
+            or "authorization_pending" in response_text.lower()
+        ):
             return AuthorizationPendingError(
                 device_code=context.get("resource_id"),
             )


### PR DESCRIPTION
# Bump FastMCP to 3.x

## Summary
- Migrate from `mcp.server.fastmcp` to the standalone `fastmcp` 3.x package across all server modules; bump `mcp>=1.27.0` and `pydantic>=2.13,<3`.
- Patch `python-dotenv` to `>=1.2.2` to pull in the upstream fix required by the new dependency tree.
- Refactor `server/prompts/basic.py` to return `fastmcp.prompts.Message` objects instead of raw `dict` payloads and lift prompt text into module-level constants.
- Pass the resolved package version into `FastMCP(...)` so the server advertises its real version to clients.
- Drop `-e` from the user-facing `pip install` instruction in the README (editable installs aren't appropriate for end users).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies and added FastMCP; tightened pydantic and python-dotenv constraints
  * Changed local install instructions from editable to standard install
* **Refactor**
  * Switched server integration to the FastMCP surface and standardized server naming/version output
* **Bug Fixes**
  * OAuth device-token 400 responses are now treated as “authorization pending” where appropriate
* **Tests**
  * Test suite now uses a shared FastMCP inspection report and simplified startup validation
* **Documentation**
  * Replaced Node-based inspector instructions with FastMCP CLI workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wwiens/trakt_mcpserver/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->