### PR TITLE
feat: add uvx install option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -239,7 +239,7 @@ Skipping is fine — the existing `ruff` dev commands and the CI `pr-title-lint.
 
 ### Authentication
 - OAuth device code flow
-- Tokens in `auth_token.json` (gitignored)
+- Tokens persisted to `~/.trakt-mcp/auth_token.json` by default; override with `TRAKT_AUTH_TOKEN_PATH` (Docker images set this to `/data/auth_token.json`)
 - `TraktAuthToken` model handles persistence
 - Global `active_auth_flow` tracks authorization
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ npx @modelcontextprotocol/inspector --cli python server.py --method tools/call  
 
 ## Versioning & Releases
 
-**Single source of truth**: `pyproject.toml` `[project] version`. Read at runtime via `importlib.metadata.version("trakt-mcp-server")`. Never hard-code `__version__`.
+**Single source of truth**: `pyproject.toml` `[project] version`. Read at runtime via `importlib.metadata.version("trakt-mcp")`. Never hard-code `__version__`.
 
 **Runtime dependencies SSOT**: `pyproject.toml [project] dependencies`. Both Dockerfiles extract this list at build time using `tomllib`. Do not maintain a parallel `requirements.txt`.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG VERSION=dev
 ARG REPO_URL=https://github.com/wwiens/trakt_mcpserver
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL org.opencontainers.image.source=${REPO_URL}
-LABEL org.opencontainers.image.title="trakt-mcp-server"
+LABEL org.opencontainers.image.title="trakt-mcp"
 LABEL org.opencontainers.image.description="MCP server for Trakt.tv"
 
 # Install Python and tools (base image is Alpine)

--- a/Dockerfile.stdio
+++ b/Dockerfile.stdio
@@ -7,7 +7,7 @@ ARG VERSION=dev
 ARG REPO_URL=https://github.com/wwiens/trakt_mcpserver
 LABEL org.opencontainers.image.version=${VERSION}
 LABEL org.opencontainers.image.source=${REPO_URL}
-LABEL org.opencontainers.image.title="trakt-mcp-server"
+LABEL org.opencontainers.image.title="trakt-mcp"
 LABEL org.opencontainers.image.description="MCP server for Trakt.tv"
 
 # Install curl for potential debugging (optional, can be removed for smaller image)

--- a/README.md
+++ b/README.md
@@ -53,15 +53,14 @@ uvx --from git+https://github.com/wwiens/trakt_mcpserver@v0.9.0 trakt-mcp
       ],
       "env": {
         "TRAKT_CLIENT_ID": "your_client_id",
-        "TRAKT_CLIENT_SECRET": "your_client_secret",
-        "TRAKT_AUTH_TOKEN_PATH": "/absolute/path/to/auth_token.json"
+        "TRAKT_CLIENT_SECRET": "your_client_secret"
       }
     }
   }
 }
 ```
 
-`TRAKT_AUTH_TOKEN_PATH` is recommended because uvx runs in an ephemeral temp directory — without it, the auth token file lands somewhere unpredictable and is lost between runs.
+Your Trakt OAuth token is persisted to `~/.trakt-mcp/auth_token.json` (the directory is created on first login), so authorization survives across uvx invocations. To override the location — e.g. for Docker volumes or to keep multiple isolated accounts — set `TRAKT_AUTH_TOKEN_PATH` to an absolute path.
 
 ### Local Installation
 
@@ -803,7 +802,7 @@ The server uses Trakt's device authentication flow:
 2. You'll receive a code and a URL to visit on your browser
 3. After entering the code on the Trakt website and authorizing the app, inform Claude that you've completed the authorization
 4. Claude will check the authentication status and then fetch your personal data
-5. Your authentication token is stored securely in `auth_token.json` for future requests. In Docker, this is at `/data/auth_token.json` — mount a volume at `/data` (e.g. `-v trakt_auth:/data`) to persist auth across container recreations.
+5. Your authentication token is stored securely in `~/.trakt-mcp/auth_token.json` for future requests, with `0o600` permissions. Override the location with the `TRAKT_AUTH_TOKEN_PATH` env var; Docker images set it to `/data/auth_token.json` — mount a volume at `/data` (e.g. `-v trakt_auth:/data`) to persist auth across container recreations.
 
 You can log out at any time using the `clear_auth` tool.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,43 @@ docker run -d --rm --name trakt_mcpserver \
   ghcr.io/wwiens/trakt_mcpserver:latest
 ```
 
+### Run with uvx (no clone, no install)
+
+Requires [uv](https://docs.astral.sh/uv/) installed.
+
+```bash
+uvx --from git+https://github.com/wwiens/trakt_mcpserver trakt-mcp
+```
+
+Pin to a release tag for reproducibility:
+
+```bash
+uvx --from git+https://github.com/wwiens/trakt_mcpserver@v0.9.0 trakt-mcp
+```
+
+**Claude Desktop / MCPhub configuration:**
+```json
+{
+  "mcpServers": {
+    "trakt": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/wwiens/trakt_mcpserver",
+        "trakt-mcp"
+      ],
+      "env": {
+        "TRAKT_CLIENT_ID": "your_client_id",
+        "TRAKT_CLIENT_SECRET": "your_client_secret",
+        "TRAKT_AUTH_TOKEN_PATH": "/absolute/path/to/auth_token.json"
+      }
+    }
+  }
+}
+```
+
+`TRAKT_AUTH_TOKEN_PATH` is recommended because uvx runs in an ephemeral temp directory — without it, the auth token file lands somewhere unpredictable and is lost between runs.
+
 ### Local Installation
 
 Requires Python 3.12 or newer.

--- a/client/auth/client.py
+++ b/client/auth/client.py
@@ -23,9 +23,14 @@ from ..base import BaseClient
 
 logger = logging.getLogger(__name__)
 
-# User authentication token storage path
-# Docker sets TRAKT_AUTH_TOKEN_PATH for volume-based persistence
-AUTH_TOKEN_FILE: Final[str] = os.environ.get("TRAKT_AUTH_TOKEN_PATH", "auth_token.json")
+# User authentication token storage path.
+# Default lives under the user's home so the token survives across uvx invocations
+# (uvx's CWD is a throwaway temp dir). Override via TRAKT_AUTH_TOKEN_PATH —
+# Docker images set it to /data/auth_token.json for volume-based persistence.
+AUTH_TOKEN_FILE: Final[str] = os.environ.get(
+    "TRAKT_AUTH_TOKEN_PATH",
+    os.path.expanduser("~/.trakt-mcp/auth_token.json"),
+)
 
 
 class AuthClient(BaseClient):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "trakt-mcp-server"
+name = "trakt-mcp"
 version = "0.9.0"
 description = "Model Context Protocol server bridging AI models with the Trakt.tv API."
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ dependencies = [
     "pydantic==2.11.7",
 ]
 
+[project.scripts]
+trakt-mcp = "server.main:run"
+
 [build-system]
 requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/server.py
+++ b/server.py
@@ -1,15 +1,4 @@
-# Backward compatibility - import from new modular structure
-import sys
-
-from dotenv import load_dotenv
-
-load_dotenv()
-
-from server.main import mcp  # noqa: E402
+from server.main import run
 
 if __name__ == "__main__":
-    # Print to stderr to avoid polluting stdout (required for stdio transport)
-    print("Starting Trakt MCP server...", file=sys.stderr)
-    print("Run 'mcp dev server.py' to test with the MCP Inspector", file=sys.stderr)
-    print("Run 'mcp install server.py' to install in Claude Desktop", file=sys.stderr)
-    mcp.run()
+    run()

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,6 +1,12 @@
 """Modular Trakt MCP server."""
 
-from .main import create_server, mcp
+# Load .env before any submodule import, so module-level env reads
+# (e.g. AUTH_TOKEN_FILE in client.auth.client) see the file's values.
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from .main import create_server, mcp  # noqa: E402
 
 __all__ = [
     "create_server",

--- a/server/main.py
+++ b/server/main.py
@@ -72,11 +72,11 @@ def create_server() -> FastMCP:
         Configured FastMCP server instance
     """
     try:
-        version = _pkg_version("trakt-mcp-server")
+        version = _pkg_version("trakt-mcp")
     except PackageNotFoundError:
         version = "0.0.0+dev"
-    logger.info("Starting trakt-mcp-server v%s", version)
-    mcp = FastMCP(name="trakt-mcp-server", lifespan=_lifespan)
+    logger.info("Starting trakt-mcp v%s", version)
+    mcp = FastMCP(name="trakt-mcp", lifespan=_lifespan)
     for register in REGISTRATIONS:
         register(mcp)
     logger.info("All Trakt MCP modules registered successfully")

--- a/server/main.py
+++ b/server/main.py
@@ -87,9 +87,15 @@ def create_server() -> FastMCP:
 mcp = create_server()
 
 
-if __name__ == "__main__":
+def run() -> None:
+    """Console-script entry point (used by `[project.scripts]` and uvx)."""
+    from dotenv import load_dotenv
+
+    load_dotenv()
     # Print to stderr to avoid polluting stdout (required for stdio transport)
     print("Starting Trakt MCP server...", file=sys.stderr)
-    print("Run 'mcp dev server.py' to test with the MCP Inspector", file=sys.stderr)
-    print("Run 'mcp install server.py' to install in Claude Desktop", file=sys.stderr)
     mcp.run()
+
+
+if __name__ == "__main__":
+    run()

--- a/server/main.py
+++ b/server/main.py
@@ -89,9 +89,6 @@ mcp = create_server()
 
 def run() -> None:
     """Console-script entry point (used by `[project.scripts]` and uvx)."""
-    from dotenv import load_dotenv
-
-    load_dotenv()
     # Print to stderr to avoid polluting stdout (required for stdio transport)
     print("Starting Trakt MCP server...", file=sys.stderr)
     mcp.run()


### PR DESCRIPTION
- Add a `trakt-mcp` console-script entry point (`[project.scripts]` in `pyproject.toml`) so the server can be run via `uvx --from git+https://github.com/wwiens/trakt_mcpserver trakt-mcp` with no clone or local install.
- Refactor startup: extract `run()` into `server/main.py`; `server.py` becomes a thin shim that delegates to it. `mcp dev server.py` and `python server.py` continue to work.
- Move `.env` loading into `server/__init__.py` so it runs before submodule imports. `client/auth/client.py` captures `TRAKT_AUTH_TOKEN_PATH` in a module-level `Final` at import time; the original `load_dotenv()` placement inside `run()` left that constant frozen to the default before `.env` was applied.
- Change the default token path from a relative `auth_token.json` (CWD-dependent — useless under uvx's throwaway temp dir) to an absolute `~/.trakt-mcp/auth_token.json`. uvx now works with no extra config; `TRAKT_AUTH_TOKEN_PATH` remains available as an override and is still what Docker images set to `/data/auth_token.json`.
- Rename the PyPI dist from `trakt-mcp-server` to `trakt-mcp` (done pre-publish; package has never shipped to PyPI). Aligns dist name, console-script, FastMCP server identifier, log output, and OCI image titles so future `pip install trakt-mcp` matches the binary name — the standard single-binary CLI convention.
- README + CLAUDE.md updated: the uvx config block no longer needs `TRAKT_AUTH_TOKEN_PATH`, and the Authentication section documents the new default path and `0o600` permissions. CLAUDE.md's versioning section reflects the new dist-name lookup.

## Behavior changes

- **Token location**: anyone running `python server.py` from a clone with a pre-existing `auth_token.json` in the repo root will need to either `mv ./auth_token.json ~/.trakt-mcp/auth_token.json` or re-authenticate once via the device-code flow. Docker users are unaffected (image env already sets the override).
- **Dist name**: existing local editable installs under `trakt-mcp-server` should be uninstalled (`pip uninstall trakt-mcp-server`) and reinstalled (`pip install -e .`) so `importlib.metadata.version("trakt-mcp")` resolves. No PyPI consumers affected (never published).
- **FastMCP server identifier**: the server now self-reports as `trakt-mcp` during MCP handshake. Cosmetic — clients identify servers by the local config key (e.g. `"trakt"` in `mcpServers` JSON), not by this name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified OAuth token storage default (~/.trakt-mcp/auth_token.json), Docker volume path, and TRAKT_AUTH_TOKEN_PATH override
  * Added uvx "no clone, no install" quick-start and full example configurations

* **New Features**
  * Added a CLI entrypoint for easy server startup

* **Improvements**
  * Default token persistence moved to the user home directory
  * Project/package name and image title standardized to "trakt-mcp"
  * Simplified startup messaging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wwiens/trakt_mcpserver/pull/51?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->