### PR TITLE
ci: publish to PyPI on GitHub Release

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -25,4 +25,4 @@ jobs:
           python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,28 @@
+name: 📦 Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish-pypi.yml`, triggered on `release: [published]`.
- Builds sdist + wheel from the release tag and uploads to PyPI via `pypa/gh-action-pypi-publish` using **Trusted Publishing** (OIDC, `id-token: write`) — no `PYPI_API_TOKEN` secret to manage.
- Slots in behind the existing `release.yml`: semantic-release (or the first-run bootstrap) cuts the GitHub Release, this workflow takes over and pushes to PyPI.

## Why

`release.yml` already produces versioned GHCR images on every release but never publishes the package itself. Closing that gap so users can `pip install trakt-mcp` once a Trusted Publisher is configured on PyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated package publishing: releases now trigger an automated workflow that builds and publishes Python distributions to PyPI, streamlining delivery of updates and reducing manual release steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wwiens/trakt_mcpserver/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->