### PR TITLE
ci: SHA-pin third-party actions

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50  # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run python-semantic-release
         id: release
         if: steps.bootstrap.outputs.released != 'true'
-        uses: python-semantic-release/python-semantic-release@v10
+        uses: python-semantic-release/python-semantic-release@350c48fcb3ffcdfd2e0a235206bc2ecea6b69df0  # v10.5.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -71,10 +71,10 @@ jobs:
         with:
           ref: ${{ needs.semantic-release.outputs.tag }}
 
-      - uses: docker/setup-qemu-action@v4
-      - uses: docker/setup-buildx-action@v4
+      - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4.1.0
 
-      - uses: docker/login-action@v4
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -82,7 +82,7 @@ jobs:
 
       - name: Metadata (SSE)
         id: meta-sse
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -90,7 +90,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push SSE image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           file: ./Dockerfile
@@ -104,7 +104,7 @@ jobs:
 
       - name: Metadata (stdio versioned)
         id: meta-stdio
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         with:
           images: ghcr.io/${{ github.repository }}
           flavor: suffix=-stdio
@@ -114,14 +114,14 @@ jobs:
 
       - name: Metadata (stdio legacy alias — drop at v1.0.0)
         id: meta-stdio-legacy
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=stdio
 
       - name: Build and push stdio image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
         with:
           context: .
           file: ./Dockerfile.stdio


### PR DESCRIPTION
Pin all third-party GitHub Actions to full commit SHAs to mitigate supply-chain risk from tag mutation. Each pin carries a trailing version comment for grep-ability:

- python-semantic-release/python-semantic-release → v10.5.3
- docker/setup-qemu-action → v4.0.0
- docker/setup-buildx-action → v4.1.0
- docker/login-action → v4.2.0
- docker/metadata-action → v6.1.0 (3 instances)
- docker/build-push-action → v7.2.0 (2 instances)
- amannn/action-semantic-pull-request → v6.1.1

Without Dependabot these SHAs will need manual bumps when upstream ships security or feature updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wwiens/trakt_mcpserver/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->