### PR TITLE
feat: publish `-novolume` image variant for PaaS providers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          target: with-volume
           push: true
           platforms: linux/amd64,linux/arm64
           build-args: |
@@ -101,6 +102,30 @@ jobs:
             REPO_URL=https://github.com/${{ github.repository }}
           tags: ${{ steps.meta-sse.outputs.tags }}
           labels: ${{ steps.meta-sse.outputs.labels }}
+
+      - name: Metadata (SSE no-volume)
+        id: meta-sse-novolume
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9  # v6.1.0
+        with:
+          images: ghcr.io/${{ github.repository }}
+          flavor: suffix=-novolume
+          tags: |
+            type=raw,value=${{ needs.semantic-release.outputs.version }}
+            type=raw,value=latest
+
+      - name: Build and push SSE no-volume image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
+        with:
+          context: .
+          file: ./Dockerfile
+          target: no-volume
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ needs.semantic-release.outputs.version }}
+            REPO_URL=https://github.com/${{ github.repository }}
+          tags: ${{ steps.meta-sse-novolume.outputs.tags }}
+          labels: ${{ steps.meta-sse-novolume.outputs.labels }}
 
       - name: Metadata (stdio versioned)
         id: meta-stdio

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # mcp-proxy + Trakt MCP server (SSE -> stdio)
-FROM ghcr.io/sparfenyuk/mcp-proxy:latest
+FROM ghcr.io/sparfenyuk/mcp-proxy:latest AS base
 
 ARG VERSION=dev
 ARG REPO_URL=https://github.com/wwiens/trakt_mcpserver
@@ -51,9 +51,6 @@ ENV TRAKT_AUTH_TOKEN_PATH=/data/auth_token.json
 # Expose SSE port (will be overridden by runtime environment)
 EXPOSE 8080
 
-# Declare volume for auth token persistence across container restarts
-VOLUME /data
-
 # Switch to non-root user
 USER appuser
 
@@ -63,3 +60,11 @@ USER appuser
 # `--` separates proxy args from child args
 ENTRYPOINT ["mcp-proxy"]
 CMD ["--host", "0.0.0.0", "--port", "8080", "--pass-environment", "--", "python3", "/app/trakt_mcpserver/server.py"]
+
+# ── Variants ──────────────────────────────────────────────────────────────
+# PaaS-compatible (Railway, Fly.io, etc. that reject Dockerfile VOLUME).
+FROM base AS no-volume
+
+# Default: declares /data as a volume so auth persists without an explicit -v.
+FROM base AS with-volume
+VOLUME /data

--- a/README.md
+++ b/README.md
@@ -802,7 +802,7 @@ The server uses Trakt's device authentication flow:
 2. You'll receive a code and a URL to visit on your browser
 3. After entering the code on the Trakt website and authorizing the app, inform Claude that you've completed the authorization
 4. Claude will check the authentication status and then fetch your personal data
-5. Your authentication token is stored securely in `~/.trakt-mcp/auth_token.json` for future requests, with `0o600` permissions. Override the location with the `TRAKT_AUTH_TOKEN_PATH` env var; Docker images set it to `/data/auth_token.json` — mount a volume at `/data` (e.g. `-v trakt_auth:/data`) to persist auth across container recreations.
+5. Your authentication token is stored securely in `~/.trakt-mcp/auth_token.json` for future requests, with `0o600` permissions. Override the location with the `TRAKT_AUTH_TOKEN_PATH` env var; Docker images set it to `/data/auth_token.json` — mount a volume at `/data` (e.g. `-v trakt_auth:/data`) to persist auth across container recreations. On PaaS providers (Railway, Fly.io) that reject the Dockerfile `VOLUME` instruction, use the `:latest-novolume` image and configure a platform-managed mount at `/data` instead.
 
 You can log out at any time using the `clear_auth` tool.
 
@@ -813,6 +813,7 @@ Two Docker images are available with different transport mechanisms. Each releas
 | Image Tag | Transport | Use Case |
 |-----------|-----------|----------|
 | `:latest` | SSE (HTTP) | Remote access, web clients, docker-compose |
+| `:latest-novolume` | SSE (HTTP) | PaaS like Railway/Fly.io that reject Dockerfile `VOLUME` |
 | `:latest-stdio` | stdio | MCPhub, Claude Desktop, local MCP clients |
 | `:stdio` | stdio | **Deprecated alias for `:latest-stdio` — will be removed at v1.0.0** |
 
@@ -868,6 +869,22 @@ docker run -d --rm --name trakt_mcpserver \
   -v trakt_auth:/data \
   -p 8080:8080 \
   trakt_mcpserver
+```
+
+### Deploying to PaaS (Railway, Fly.io)
+
+Some PaaS providers reject or discard Docker images that declare a `VOLUME` instruction, because they manage persistent storage through their own UI rather than Docker volumes. For these platforms, pull the `:latest-novolume` variant (functionally identical to `:latest`, just without the `VOLUME /data` declaration):
+
+```bash
+docker pull ghcr.io/wwiens/trakt_mcpserver:latest-novolume
+```
+
+To persist auth across restarts, attach platform-managed storage at `/data` (e.g. a Railway Volume mounted at `/data`), or override `TRAKT_AUTH_TOKEN_PATH` to a path on storage your platform already persists.
+
+To build the same variant locally:
+
+```bash
+docker build --target no-volume -t trakt_mcpserver:novolume .
 ```
 
 ### Using `docker compose`

--- a/README.md
+++ b/README.md
@@ -873,7 +873,7 @@ docker run -d --rm --name trakt_mcpserver \
 
 ### Deploying to PaaS (Railway, Fly.io)
 
-Some PaaS providers reject or discard Docker images that declare a `VOLUME` instruction, because they manage persistent storage through their own UI rather than Docker volumes. For these platforms, pull the `:latest-novolume` variant (functionally identical to `:latest`, just without the `VOLUME /data` declaration):
+Some PaaS providers reject or discard Docker images that declare a `VOLUME` instruction, because they manage persistent storage through their own UI rather than Docker volumes. For these platforms, pull the `:latest-novolume` variant — identical to `:latest` except the `VOLUME /data` declaration is omitted, so the platform's own storage layer can mount at `/data` without conflict:
 
 ```bash
 docker pull ghcr.io/wwiens/trakt_mcpserver:latest-novolume


### PR DESCRIPTION
## Summary

- Splits the SSE `Dockerfile` into a shared `base` stage plus two final targets: `with-volume` (default `:latest`, declares `VOLUME /data`) and `no-volume` (`:latest-novolume`, identical but omits the `VOLUME` directive).
- Wires `release.yml` to build and push both variants on every release (multi-arch: `linux/amd64`, `linux/arm64`), using the existing tag/version metadata flow.
- Documents the new variant and PaaS deployment path (Railway, Fly.io) in `README.md`, including a local `--target no-volume` build recipe and guidance on mounting platform-managed storage at `/data`.

## Motivation

Railway, Fly.io, and similar PaaS providers reject or silently discard Docker images that declare `VOLUME`, since they manage persistent storage themselves. The default `:latest` image is unchanged for existing `docker run -v` / `docker compose` users; the new `:latest-novolume` tag lets PaaS users deploy the same server without forking the Dockerfile.

## Changes

| File | Change |
|---|---|
| `Dockerfile` | Renamed pipeline into `base` stage; added `no-volume` and `with-volume` final targets. |
| `.github/workflows/release.yml` | Added a second `build-push-action` step that targets `no-volume` and tags with the `-novolume` suffix via `docker/metadata-action` flavor. |
| `README.md` | Added the `:latest-novolume` row to the image table, a "Deploying to PaaS" section, and a note in the auth-persistence paragraph. |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `:latest-novolume` Docker image variant for PaaS platforms (Railway/Fly.io) that don't support Dockerfile VOLUME declarations.

* **Documentation**
  * Expanded authentication token storage instructions with file permission guidance.
  * Added deployment guide for PaaS platforms using the new image variant, including persistence and configuration options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wwiens/trakt_mcpserver/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->