### PR TITLE
ci: auto-label PRs by conventional commit title and file paths

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,40 @@
+version: 1
+labels:
+  - label: "documentation"
+    title: "^docs(\\(.+\\))?!?:"
+  - label: "documentation"
+    files:
+      - ".*\\.md$"
+
+  - label: "bug"
+    title: "^fix(\\(.+\\))?!?:"
+
+  - label: "enhancement"
+    title: "^feat(\\(.+\\))?!?:"
+
+  - label: "ci"
+    title: "^(ci|build)(\\(.+\\))?!?:"
+  - label: "ci"
+    files:
+      - "^\\.github/workflows/.*"
+      - "^Dockerfile.*"
+      - "^\\.dockerignore$"
+
+  - label: "tests"
+    title: "^test(\\(.+\\))?!?:"
+  - label: "tests"
+    files:
+      - "^tests/.*"
+
+  - label: "dependencies"
+    title: "^chore\\(deps\\)!?:"
+  - label: "dependencies"
+    files:
+      - "^pyproject\\.toml$"
+      - "^requirements.*\\.txt$"
+
+  - label: "refactor"
+    title: "^refactor(\\(.+\\))?!?:"
+
+  - label: "breaking-change"
+    title: "^[a-z]+(\\(.+\\))?!:"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: 🏷️ Label PR
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: srvaroa/labeler@bf262763a8a8e191f5847873aecc0f29df84f957  # v1.14.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `srvaroa/labeler` workflow that labels PRs on open/edit/sync/reopen using both PR title (Conventional Commit type) and changed file paths.
- Ship `.github/labeler.yml` rules covering `documentation`, `bug`, `enhancement`, `ci`, `tests`, `dependencies`, `refactor`, and `breaking-change` (auto-applied when the title uses the `!` breaking marker).
- Action is SHA-pinned (`bf262763…` / v1.14.0) to stay consistent with the existing third-party action pinning policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated labeling for pull requests and issues. Labels are now automatically applied based on title patterns and modified file paths, including categories for documentation, bug fixes, enhancements, CI/CD, tests, dependencies, refactoring, and breaking changes. This improves project organization and workflow efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wwiens/trakt_mcpserver/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->