### PR TITLE
docs: remote deployment guide for claude.ai (transport, Cloudflare Tunnel, WAF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,35 @@ Add to your Claude Desktop MCP configuration file:
 }
 ```
 
+## 🔒 Deploying as a remote server for claude.ai
+
+Running this server behind a public URL so **claude.ai** (web + mobile) can use it as a custom connector. Two things commonly trip people up:
+
+### Transport: register `/mcp`, not `/sse`
+
+claude.ai's custom connector expects **Streamable HTTP**. The `:latest` image (mcp-proxy) serves **both** `/sse` (legacy) and `/mcp` (Streamable HTTP) on port 8080 — register the connector URL as `https://your-host/mcp`. Using `/sse` triggers a transport-negotiation error (and can cascade into a confusing OAuth prompt).
+
+### If the host blocks inbound 80/443 — use a Cloudflare Tunnel
+
+Some VPS providers block inbound ports on certain IPs even with the OS firewall open (SSH works, 80/443 time out from the public internet). Then Let's Encrypt/Caddy can't complete a challenge and claude.ai can't reach you either. A **Cloudflare Tunnel** fixes this — the server dials **outbound** to Cloudflare, no inbound ports required:
+
+```bash
+# on the server, alongside the container (SSE on 127.0.0.1:8899)
+cloudflared service install <TUNNEL_TOKEN>
+# tunnel ingress:  trakt.yourdomain.com -> http://localhost:8899
+# DNS: CNAME  trakt -> <tunnel-id>.cfargotunnel.com  (proxied)
+```
+
+Cloudflare terminates TLS and routes to your container. Add `disableChunkedEncoding: true` to the ingress rule if streaming stalls.
+
+### Locking down the open `/mcp` endpoint
+
+The MCP endpoint has **no auth** — anyone with the URL gets full access, including write tools. claude.ai's web connector **can't send custom headers** (only OAuth), so a bearer token or Cloudflare Access service-token won't work with it. Options:
+
+- **Full protection** — implement MCP OAuth 2.1 (DCR + PKCE + `WWW-Authenticate` + protected-resource metadata) so claude.ai runs the flow itself. (Heads-up: claude.ai-web OAuth against self-hosted servers is currently flaky — test on your own account and keep Claude Code CLI as a reliable fallback.)
+- **Practical palliative** — a Cloudflare WAF rule allowing only Anthropic's connector egress IPs (`160.79.104.0/21`, `2607:6bc0::/48`; see [Anthropic IP addresses](https://platform.claude.com/docs/en/api/ip-addresses)). Blocks bots/scanners/`curl` while keeping claude.ai working. It's **not per-user** (anyone who knows the URL and adds it as *their own* connector still egresses from those IPs), but it's a big step up from a fully-open endpoint.
+- For **Claude Code CLI** (not web) you can simply use `.mcp.json` `headers.Authorization: Bearer …` or a Cloudflare Access service token — both work there.
+
 ## ✨ Features
 
 ### 🌎 Public Trakt Data


### PR DESCRIPTION
## Add a "Deploying as a remote server for claude.ai" section to the README

Practical deployment notes for running this server as a claude.ai custom connector, based on a real deployment. Covers three gotchas that aren't obvious from the current docs:

1. **Transport** — register `/mcp` (Streamable HTTP), not `/sse`; the `:latest` image serves both.
2. **Cloudflare Tunnel** — for hosts that block inbound 80/443 (outbound-only, no open ports).
3. **Locking down the authless `/mcp`** — why bearer/custom headers don't work with claude.ai-web, plus a WAF IP-allowlist palliative and the OAuth path.

Docs-only change (one README section). No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
