### PR TITLE
build(deps-dev): upgrade and pin pyright to 1.1.411

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 pytest==9.0.3
 pytest-asyncio>=1.0
-pyright>=1.1.409
+pyright==1.1.411
 ruff==0.15.12
 pip-audit>=2.9.0
 types-requests>=2.32.0

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -4,7 +4,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import pytest
@@ -49,7 +49,7 @@ async def test_auth_flow_integration() -> None:
         "token_type": "bearer",
     }
 
-    empty_flow: dict[str, Any] = {}
+    empty_flow: dict[str, object] = {}
     with (
         patch("httpx.AsyncClient") as mock_client,
         patch("builtins.open", mock_open()),

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -4,7 +4,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import pytest
@@ -49,6 +49,7 @@ async def test_auth_flow_integration() -> None:
         "token_type": "bearer",
     }
 
+    empty_flow: dict[str, Any] = {}
     with (
         patch("httpx.AsyncClient") as mock_client,
         patch("builtins.open", mock_open()),
@@ -57,7 +58,7 @@ async def test_auth_flow_integration() -> None:
             os.environ,
             {"TRAKT_CLIENT_ID": "test_id", "TRAKT_CLIENT_SECRET": "test_secret"},
         ),
-        patch("server.auth.tools.active_auth_flow", {}),
+        patch("server.auth.tools.active_auth_flow", empty_flow),
         patch("os.path.exists", return_value=True),
     ):
         device_code_mock = MagicMock()

--- a/tests/server/auth/test_auth_tools.py
+++ b/tests/server/auth/test_auth_tools.py
@@ -16,9 +16,10 @@ from utils.api.error_types import AuthorizationPendingError
 
 @pytest.mark.asyncio
 async def test_start_device_auth():
+    empty_flow: dict[str, Any] = {}
     with (
         patch("server.auth.tools.AuthClient") as mock_client_class,
-        patch("server.auth.tools.active_auth_flow", {}),
+        patch("server.auth.tools.active_auth_flow", empty_flow),
     ):
         mock_client = mock_client_class.return_value
         mock_client.is_authenticated.return_value = False
@@ -59,9 +60,10 @@ async def test_start_device_auth_already_authenticated():
 
 @pytest.mark.asyncio
 async def test_check_auth_status_no_active_flow():
+    empty_flow: dict[str, Any] = {}
     with (
         patch("server.auth.tools.AuthClient") as mock_client_class,
-        patch("server.auth.tools.active_auth_flow", {}),
+        patch("server.auth.tools.active_auth_flow", empty_flow),
     ):
         mock_client = mock_client_class.return_value
         mock_client.is_authenticated.return_value = False
@@ -263,9 +265,10 @@ async def test_clear_auth():
 
 @pytest.mark.asyncio
 async def test_clear_auth_not_authenticated():
+    empty_flow: dict[str, Any] = {}
     with (
         patch("server.auth.tools.AuthClient") as mock_client_class,
-        patch("server.auth.tools.active_auth_flow", {}),
+        patch("server.auth.tools.active_auth_flow", empty_flow),
     ):
         mock_client = mock_client_class.return_value
         mock_client.clear_auth_token.return_value = False

--- a/tests/server/auth/test_auth_tools.py
+++ b/tests/server/auth/test_auth_tools.py
@@ -16,7 +16,7 @@ from utils.api.error_types import AuthorizationPendingError
 
 @pytest.mark.asyncio
 async def test_start_device_auth():
-    empty_flow: dict[str, Any] = {}
+    empty_flow: dict[str, object] = {}
     with (
         patch("server.auth.tools.AuthClient") as mock_client_class,
         patch("server.auth.tools.active_auth_flow", empty_flow),
@@ -60,7 +60,7 @@ async def test_start_device_auth_already_authenticated():
 
 @pytest.mark.asyncio
 async def test_check_auth_status_no_active_flow():
-    empty_flow: dict[str, Any] = {}
+    empty_flow: dict[str, object] = {}
     with (
         patch("server.auth.tools.AuthClient") as mock_client_class,
         patch("server.auth.tools.active_auth_flow", empty_flow),
@@ -265,7 +265,7 @@ async def test_clear_auth():
 
 @pytest.mark.asyncio
 async def test_clear_auth_not_authenticated():
-    empty_flow: dict[str, Any] = {}
+    empty_flow: dict[str, object] = {}
     with (
         patch("server.auth.tools.AuthClient") as mock_client_class,
         patch("server.auth.tools.active_auth_flow", empty_flow),


### PR DESCRIPTION
## Summary

CI's `typecheck` job installs pyright via `requirements-dev.txt`, where it was declared
unpinned as `pyright>=1.1.409`. The pyright PyPI wrapper began resolving to **1.1.411**, which
is stricter about `reportUnknownArgumentType` under the repo's `typeCheckingMode = "strict"`.
This surfaced **4 type errors** — all pre-existing on `main`, unrelated to any feature branch —
caused by empty `{}` dict literals passed to `mock.patch`, which 1.1.411 now infers as
`dict[Unknown, Unknown]`.

This PR pins pyright so the type-checker version no longer floats (CI can't silently break on a
future pyright release) and fixes the 4 errors so the suite is green on 1.1.411.

## Changes

- **`requirements-dev.txt`** — `pyright>=1.1.409` → `pyright==1.1.411`. Exact pin matches the
  existing `ruff==0.15.12` / `pytest==9.0.3` convention. Pinning the wrapper is sufficient — it
  installs the matching 1.1.411 binary by default, so no `PYRIGHT_PYTHON_FORCE_VERSION` env is
  needed and the bare `pyright` invocation in `ci.yml` is unchanged.
- **4 test sites** — replaced inline `patch("server.auth.tools.active_auth_flow", {})` with a
  locally-annotated `empty_flow: dict[str, Any] = {}`, mirroring the source declaration
  `active_auth_flow: AuthFlowState | dict[str, Any]` (`server/auth/tools.py:32`). A fresh local
  per test (not a shared constant) avoids cross-test mutation leakage, since `patch` installs the
  object itself and the code under test mutates `active_auth_flow`.
  - `tests/integration/test_integration.py` (+ `Any` added to the `typing` import)
  - `tests/server/auth/test_auth_tools.py` (3 sites; `Any` already imported)

No production code, CI YAML, or `[tool.pyright]` config changes.

## Scope note

The fix covers exactly the 4 reported sites — confirmed no other empty-`{}` `patch(...)`
occurrences exist. The non-empty `active_auth_flow` variants elsewhere in the auth tests already
have known types (`dict[str, str]` / `dict[str, int | str]`) and are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the development tooling version for more consistent project setup and validation.

* **Tests**
  * Improved typing in authentication integration and workflow tests.
  * Updated test setup for clearer, more reliable handling of empty authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->